### PR TITLE
Import the full Linebender lint set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "color",
-    "color_operations",
-]
+members = ["color", "color_operations"]
 
 [workspace.package]
 # Color version, also used by other packages which want to mimic Color's version.
@@ -23,6 +20,8 @@ repository = "https://github.com/linebender/color"
 [workspace.lints]
 rust.unsafe_code = "forbid"
 
+# LINEBENDER LINT SET - v1
+# See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"
 rust.non_ascii_idents = "forbid"
 rust.non_local_definitions = "forbid"
@@ -44,11 +43,14 @@ rust.unused_macro_rules = "warn"
 rust.unused_qualifications = "warn"
 rust.variant_size_differences = "warn"
 
+clippy.allow_attributes = "warn"
 clippy.allow_attributes_without_reason = "warn"
+clippy.cast_possible_truncation = "warn"
 clippy.collection_is_never_read = "warn"
 clippy.dbg_macro = "warn"
 clippy.debug_assert_with_mut_call = "warn"
 clippy.doc_markdown = "warn"
+clippy.exhaustive_enums = "warn"
 clippy.fn_to_numeric_cast_any = "forbid"
 clippy.infinite_loop = "warn"
 clippy.large_include_file = "warn"
@@ -69,6 +71,12 @@ clippy.todo = "warn"
 clippy.unseparated_literal_suffix = "warn"
 clippy.use_self = "warn"
 clippy.wildcard_imports = "warn"
+
+clippy.cargo_common_metadata = "warn"
+clippy.negative_feature_names = "warn"
+clippy.redundant_feature_names = "warn"
+clippy.wildcard_dependencies = "warn"
+# END LINEBENDER LINT SET
 
 [workspace.dependencies]
 color = { version = "0.1.0", path = "color", default-features = false }

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -9,6 +9,9 @@ categories = ["graphics"]
 repository.workspace = true
 rust-version.workspace = true
 
+# Whilst we prepare the initial release
+publish = false
+
 [features]
 default = ["std"]
 std = []

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// LINEBENDER LINT SET - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
 
 //! # Color

--- a/color_operations/Cargo.toml
+++ b/color_operations/Cargo.toml
@@ -9,6 +9,9 @@ categories = []
 repository.workspace = true
 rust-version.workspace = true
 
+# Whilst we prepare the initial release
+publish = false
+
 [features]
 default = ["std"]
 std = []

--- a/color_operations/src/lib.rs
+++ b/color_operations/src/lib.rs
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// LINEBENDER LINT SET - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
 
 //! # Color Operations
 


### PR DESCRIPTION
This brings us up-to-date with https://linebender.org/wiki/canonical-lints/