### PR TITLE
Match CI doc testing with docs.rs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,11 +260,13 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
-      # We test documentation using nightly to match docs.rs. This prevents potential breakages
+      # We test documentation using nightly to match docs.rs.
       - name: cargo doc
-        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: '--cfg docsrs -D warnings'
 
-  # If this fails, consider changing your text or adding something to .typos.toml
+  # If this fails, consider changing your text or adding something to .typos.toml.
   typos:
     runs-on: ubuntu-latest
     steps:

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -12,16 +12,16 @@ rust-version.workspace = true
 # Whilst we prepare the initial release
 publish = false
 
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
 [features]
 default = ["std"]
 std = []
 libm = ["dep:libm"]
-
-[package.metadata.docs.rs]
-all-features = true
-default-target = "x86_64-unknown-linux-gnu"
-# Color is entirely platform-agnostic, so only display docs for one platform
-targets = []
 
 [dependencies]
 

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // LINEBENDER LINT SET - v1
 // See https://linebender.org/wiki/canonical-lints/
 // These lints aren't included in Cargo.toml because they

--- a/color/src/tagged.rs
+++ b/color/src/tagged.rs
@@ -34,7 +34,7 @@ pub enum ColorspaceTag {
 }
 
 /// A color with a runtime colorspace tag. This type will likely get merged with
-/// [`CssColor`].
+/// [`CssColor`][crate::css::CssColor].
 #[derive(Clone, Copy, Debug)]
 pub struct TaggedColor {
     pub cs: ColorspaceTag,

--- a/color_operations/Cargo.toml
+++ b/color_operations/Cargo.toml
@@ -12,16 +12,16 @@ rust-version.workspace = true
 # Whilst we prepare the initial release
 publish = false
 
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
 [features]
 default = ["std"]
 std = ["color/std"]
 libm = ["color/libm"]
-
-[package.metadata.docs.rs]
-all-features = true
-default-target = "x86_64-unknown-linux-gnu"
-# Color is entirely platform-agnostic, so only display docs for one platform
-targets = []
 
 [dependencies]
 color = { workspace = true, default-features = false }

--- a/color_operations/src/lib.rs
+++ b/color_operations/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // LINEBENDER LINT SET - v1
 // See https://linebender.org/wiki/canonical-lints/
 // These lints aren't included in Cargo.toml because they


### PR DESCRIPTION
* Remove `-Zunstable-options -Zrustdoc-scrape-examples` from CI. It wasn't even enabled for docs.rs and we don't have any examples, so not worth enabling scraping at this point.
* Treat doc warnings as errors. Historically we've not done so due to various `rustdoc` bugs giving false positives but I got it to pass without failure right now, so perhaps better times have arrived.
* Enable the `doc_auto_cfg` feature for docs.rs which will show a little tip next to feature gated functionality informing of the crate feature flag.