### PR TITLE
Add color clipping

### DIFF
--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -76,10 +76,15 @@ pub trait ColorSpace: Clone + Copy + 'static {
         }
     }
 
-    /// Clip the color's components to the range allowed by the color space.
+    /// Clip the color's components to fit within the natural gamut of the color space.
     ///
-    /// The resultant color is guaranteed to be inside the bounds (and thus gamut) of the color
-    /// space, but may be perceptually quite distinct from the original color.
+    /// There are many possible ways to map colors outside of a color space's gamut to colors
+    /// inside the gamut. Some methods are perceptually better than others (for example, preserving
+    /// the mapped color's hue is usually preferred over preserving saturation). This method will
+    /// generally do the mathematically simplest thing, namely clamping the individual color
+    /// components' values to the color space's natural limits of those components, bringing
+    /// out-of-gamut colors just onto the gamut boundary. The resultant color may be perceptually
+    /// quite distinct from the original color.
     ///
     /// # Examples
     ///

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -76,15 +76,15 @@ pub trait ColorSpace: Clone + Copy + 'static {
         }
     }
 
-    /// Clip the color's components to the range allowed by the colorspace.
+    /// Clip the color's components to the range allowed by the color space.
     ///
-    /// The resultant color is guaranteed to be inside the bounds (and thus gamut) of the
-    /// colorspace, but may be perceptually quite distinct from the original color.
+    /// The resultant color is guaranteed to be inside the bounds (and thus gamut) of the color
+    /// space, but may be perceptually quite distinct from the original color.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use color::{Colorspace, Srgb, XyzD65};
+    /// use color::{ColorSpace, Srgb, XyzD65};
     ///
     /// assert_eq!(Srgb::clip([0.4, -0.2, 1.2]), [0.4, 0., 1.]);
     /// assert_eq!(XyzD65::clip([0.4, -0.2, 1.2]), [0.4, -0.2, 1.2]);
@@ -155,12 +155,8 @@ impl ColorSpace for LinearSrgb {
         matmul(&OKLAB_LMS_TO_SRGB, lms_scaled.map(|x| x * x * x))
     }
 
-    fn clip(src: [f32; 3]) -> [f32; 3] {
-        [
-            src[0].clamp(0., 1.),
-            src[1].clamp(0., 1.),
-            src[2].clamp(0., 1.),
-        ]
+    fn clip([r, g, b]: [f32; 3]) -> [f32; 3] {
+        [r.clamp(0., 1.), g.clamp(0., 1.), b.clamp(0., 1.)]
     }
 }
 
@@ -195,12 +191,8 @@ impl ColorSpace for Srgb {
         src.map(lin_to_srgb)
     }
 
-    fn clip(src: [f32; 3]) -> [f32; 3] {
-        [
-            src[0].clamp(0., 1.),
-            src[1].clamp(0., 1.),
-            src[2].clamp(0., 1.),
-        ]
+    fn clip([r, g, b]: [f32; 3]) -> [f32; 3] {
+        [r.clamp(0., 1.), g.clamp(0., 1.), b.clamp(0., 1.)]
     }
 }
 
@@ -228,12 +220,8 @@ impl ColorSpace for DisplayP3 {
         matmul(&LINEAR_SRGB_TO_DISPLAYP3, src).map(lin_to_srgb)
     }
 
-    fn clip(src: [f32; 3]) -> [f32; 3] {
-        [
-            src[0].clamp(0., 1.),
-            src[1].clamp(0., 1.),
-            src[2].clamp(0., 1.),
-        ]
+    fn clip([r, g, b]: [f32; 3]) -> [f32; 3] {
+        [r.clamp(0., 1.), g.clamp(0., 1.), b.clamp(0., 1.)]
     }
 }
 
@@ -263,8 +251,8 @@ impl ColorSpace for XyzD65 {
         matmul(&LINEAR_SRGB_TO_XYZ, src)
     }
 
-    fn clip(src: [f32; 3]) -> [f32; 3] {
-        src
+    fn clip([x, y, z]: [f32; 3]) -> [f32; 3] {
+        [x, y, z]
     }
 }
 
@@ -326,8 +314,8 @@ impl ColorSpace for Oklab {
         }
     }
 
-    fn clip(src: [f32; 3]) -> [f32; 3] {
-        [src[0].clamp(0., 1.), src[1], src[2]]
+    fn clip([l, a, b]: [f32; 3]) -> [f32; 3] {
+        [l.clamp(0., 1.), a, b]
     }
 }
 
@@ -380,7 +368,7 @@ impl ColorSpace for Oklch {
         }
     }
 
-    fn clip(src: [f32; 3]) -> [f32; 3] {
-        [src[0].clamp(0., 1.), src[1].max(0.), src[2]]
+    fn clip([l, c, h]: [f32; 3]) -> [f32; 3] {
+        [l.clamp(0., 1.), c.max(0.), h]
     }
 }

--- a/color/src/css.rs
+++ b/color/src/css.rs
@@ -127,13 +127,15 @@ impl CssColor {
         }
     }
 
-    /// Clip the color's components to fit within the natural gamut of the color space.
+    /// Clip the color's components to fit within the natural gamut of the color space, and clamp
+    /// the color's alpha to be in the range `[0, 1]`.
     ///
     /// See [`ColorSpace::clip`] for more details.
     #[must_use]
     pub fn clip(self) -> Self {
         let (opaque, alpha) = split_alpha(self.components);
         let components = self.cs.clip(opaque);
+        let alpha = alpha.clamp(0., 1.);
         Self {
             cs: self.cs,
             missing: self.missing,

--- a/color/src/css.rs
+++ b/color/src/css.rs
@@ -127,7 +127,7 @@ impl CssColor {
         }
     }
 
-    /// Clip the color's components to the range allowed by the color space.
+    /// Clip the color's components to fit within the natural gamut of the color space.
     ///
     /// See [`ColorSpace::clip`] for more details.
     #[must_use]

--- a/color/src/css.rs
+++ b/color/src/css.rs
@@ -127,6 +127,20 @@ impl CssColor {
         }
     }
 
+    /// Clip the color's components to the range allowed by the colorspace.
+    ///
+    /// See [`Colorspace::clip`] for more details.
+    #[must_use]
+    pub fn clip(self) -> Self {
+        let (opaque, alpha) = split_alpha(self.components);
+        let components = self.cs.clip(opaque);
+        Self {
+            cs: self.cs,
+            missing: self.missing,
+            components: add_alpha(components, alpha),
+        }
+    }
+
     fn premultiply_split(self) -> ([f32; 3], f32) {
         // Reference: §12.3 of Color 4 spec
         let (opaque, alpha) = split_alpha(self.components);

--- a/color/src/css.rs
+++ b/color/src/css.rs
@@ -127,9 +127,9 @@ impl CssColor {
         }
     }
 
-    /// Clip the color's components to the range allowed by the colorspace.
+    /// Clip the color's components to the range allowed by the color space.
     ///
-    /// See [`Colorspace::clip`] for more details.
+    /// See [`ColorSpace::clip`] for more details.
     #[must_use]
     pub fn clip(self) -> Self {
         let (opaque, alpha) = split_alpha(self.components);

--- a/color/src/tagged.rs
+++ b/color/src/tagged.rs
@@ -178,6 +178,21 @@ impl ColorSpaceTag {
             }
         }
     }
+
+    /// Clip the color's components to the range allowed by the colorspace.
+    ///
+    /// See [`Colorspace::clip`] for more details.
+    pub fn clip(self, src: [f32; 3]) -> [f32; 3] {
+        match self {
+            Self::Srgb => Srgb::clip(src),
+            Self::LinearSrgb => LinearSrgb::clip(src),
+            Self::Oklab => Oklab::clip(src),
+            Self::Oklch => Oklch::clip(src),
+            Self::DisplayP3 => DisplayP3::clip(src),
+            Self::XyzD65 => XyzD65::clip(src),
+            _ => todo!(),
+        }
+    }
 }
 
 impl TaggedColor {

--- a/color/src/tagged.rs
+++ b/color/src/tagged.rs
@@ -179,7 +179,7 @@ impl ColorSpaceTag {
         }
     }
 
-    /// Clip the color's components to the range allowed by the color space.
+    /// Clip the color's components to fit within the natural gamut of the color space.
     ///
     /// See [`ColorSpace::clip`] for more details.
     pub fn clip(self, src: [f32; 3]) -> [f32; 3] {

--- a/color/src/tagged.rs
+++ b/color/src/tagged.rs
@@ -179,9 +179,9 @@ impl ColorSpaceTag {
         }
     }
 
-    /// Clip the color's components to the range allowed by the colorspace.
+    /// Clip the color's components to the range allowed by the color space.
     ///
-    /// See [`Colorspace::clip`] for more details.
+    /// See [`ColorSpace::clip`] for more details.
     pub fn clip(self, src: [f32; 3]) -> [f32; 3] {
         match self {
             Self::Srgb => Srgb::clip(src),


### PR DESCRIPTION
Clipping colors to colorspaces' bounds is useful for e.g. final display or as part of gamut mapping.

A related method would be `Colorspace::is_in_bounds(src: [f32; 3])`, but I'm undecided whether that's useful enough to include. It could have a default implementation (`src == Self::clip(src)`). Roughly the same considerations hold for a const `Colorspace::IS_(UN)BOUNDED`.