### PR TITLE
Cleanups and renames

### DIFF
--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -6,49 +6,60 @@
 use core::any::TypeId;
 use core::marker::PhantomData;
 
-use crate::{Colorspace, ColorspaceLayout};
+use crate::{ColorSpace, ColorSpaceLayout};
 
 #[cfg(all(not(feature = "std"), not(test)))]
 use crate::floatfuncs::FloatFuncs;
 
 /// An opaque color.
 ///
-/// A color in a colorspace known at compile time, without transparency. Note
+/// A color in a color space known at compile time, without transparency. Note
 /// that "opaque" refers to the color, not the representation; the components
 /// are publicly accessible.
+///
+/// Arithmetic traits are defined on this type, and operate component-wise. A
+/// major motivation for including these is to enable weighted sums, including
+/// for spline interpolation. For cylindrical color spaces, hue fixup should
+/// be applied before interpolation.
 #[derive(Clone, Copy, Debug)]
-pub struct OpaqueColor<T> {
+pub struct OpaqueColor<CS> {
     pub components: [f32; 3],
-    pub cs: PhantomData<T>,
+    pub cs: PhantomData<CS>,
 }
 
 /// A color with an alpha channel.
 ///
-/// A color in a colorspace known at compile time, with an alpha channel.
+/// A color in a color space known at compile time, with an alpha channel.
+///
+/// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
 #[derive(Clone, Copy, Debug)]
-pub struct AlphaColor<T> {
+pub struct AlphaColor<CS> {
     pub components: [f32; 4],
-    pub cs: PhantomData<T>,
+    pub cs: PhantomData<CS>,
 }
 
 /// A color with premultiplied alpha.
 ///
-/// A color in a colorspace known at compile time, with a premultiplied
+/// A color in a color space known at compile time, with a premultiplied
 /// alpha channel.
 ///
 /// Following the convention of CSS Color 4, in cylindrical color spaces
 /// the hue channel is not premultiplied. If it were, interpolation would
 /// give undesirable results.
+///
+/// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
 #[derive(Clone, Copy, Debug)]
-pub struct PremulColor<T> {
+pub struct PremulColor<CS> {
     pub components: [f32; 4],
-    pub cs: PhantomData<T>,
+    pub cs: PhantomData<CS>,
 }
 
 /// The hue direction for interpolation.
 ///
-/// This type corresponds to `hue-interpolation-method` in the CSS Color
+/// This type corresponds to [`hue-interpolation-method`] in the CSS Color
 /// 4 spec.
+///
+/// [`hue-interpolation-method`]: https://developer.mozilla.org/en-US/docs/Web/CSS/hue-interpolation-method
 #[derive(Clone, Copy, Default, Debug)]
 #[non_exhaustive]
 pub enum HueDirection {
@@ -94,7 +105,7 @@ fn fixup_hue(h1: f32, h2: &mut f32, direction: HueDirection) {
 pub(crate) fn fixup_hues_for_interpolate(
     a: [f32; 3],
     b: &mut [f32; 3],
-    layout: ColorspaceLayout,
+    layout: ColorSpaceLayout,
     direction: HueDirection,
 ) {
     if let Some(ix) = layout.hue_channel() {
@@ -102,17 +113,17 @@ pub(crate) fn fixup_hues_for_interpolate(
     }
 }
 
-impl<T: Colorspace> OpaqueColor<T> {
+impl<CS: ColorSpace> OpaqueColor<CS> {
     pub const fn new(components: [f32; 3]) -> Self {
         let cs = PhantomData;
         Self { components, cs }
     }
 
-    pub fn convert<U: Colorspace>(self) -> OpaqueColor<U> {
-        if TypeId::of::<T>() == TypeId::of::<U>() {
+    pub fn convert<U: ColorSpace>(self) -> OpaqueColor<U> {
+        if TypeId::of::<CS>() == TypeId::of::<U>() {
             OpaqueColor::new(self.components)
         } else {
-            let lin_rgb = T::to_linear_srgb(self.components);
+            let lin_rgb = CS::to_linear_srgb(self.components);
             OpaqueColor::new(U::from_linear_srgb(lin_rgb))
         }
     }
@@ -120,7 +131,7 @@ impl<T: Colorspace> OpaqueColor<T> {
     /// Add an alpha channel.
     ///
     /// This function is the inverse of [`AlphaColor::split`].
-    pub const fn with_alpha(self, alpha: f32) -> AlphaColor<T> {
+    pub const fn with_alpha(self, alpha: f32) -> AlphaColor<CS> {
         AlphaColor::new(add_alpha(self.components, alpha))
     }
 
@@ -134,7 +145,7 @@ impl<T: Colorspace> OpaqueColor<T> {
 
     /// Linearly interpolate colors, without hue fixup.
     ///
-    /// This method produces meaningful results in rectangular colorspaces,
+    /// This method produces meaningful results in rectangular color spaces,
     /// or if hue fixup has been applied.
     #[must_use]
     pub fn lerp_rect(self, other: Self, t: f32) -> Self {
@@ -146,7 +157,12 @@ impl<T: Colorspace> OpaqueColor<T> {
     /// Adjust the hue angle of `other` so that linear interpolation results in
     /// the expected hue direction.
     pub fn fixup_hues(self, other: &mut Self, direction: HueDirection) {
-        fixup_hues_for_interpolate(self.components, &mut other.components, T::LAYOUT, direction);
+        fixup_hues_for_interpolate(
+            self.components,
+            &mut other.components,
+            CS::LAYOUT,
+            direction,
+        );
     }
 
     /// Linearly interpolate colors, with hue fixup if needed.
@@ -161,7 +177,7 @@ impl<T: Colorspace> OpaqueColor<T> {
     /// See [`Colorspace::scale_chroma`] for more details.
     #[must_use]
     pub fn scale_chroma(self, scale: f32) -> Self {
-        Self::new(T::scale_chroma(self.components, scale))
+        Self::new(CS::scale_chroma(self.components, scale))
     }
 
     /// Compute the relative luminance of the color.
@@ -169,20 +185,20 @@ impl<T: Colorspace> OpaqueColor<T> {
     /// This can be useful for choosing contrasting colors, and follows the
     /// WCAG 2.1 spec.
     pub fn relative_luminance(self) -> f32 {
-        let rgb = T::to_linear_srgb(self.components);
+        let rgb = CS::to_linear_srgb(self.components);
         0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]
     }
 }
 
-pub(crate) const fn split_alpha(x: [f32; 4]) -> ([f32; 3], f32) {
-    ([x[0], x[1], x[2]], x[3])
+pub(crate) const fn split_alpha([x, y, z, a]: [f32; 4]) -> ([f32; 3], f32) {
+    ([x, y, z], a)
 }
 
-pub(crate) const fn add_alpha(x: [f32; 3], a: f32) -> [f32; 4] {
-    [x[0], x[1], x[2], a]
+pub(crate) const fn add_alpha([x, y, z]: [f32; 3], a: f32) -> [f32; 4] {
+    [x, y, z, a]
 }
 
-impl<T: Colorspace> AlphaColor<T> {
+impl<CS: ColorSpace> AlphaColor<CS> {
     pub const fn new(components: [f32; 4]) -> Self {
         let cs = PhantomData;
         Self { components, cs }
@@ -192,26 +208,26 @@ impl<T: Colorspace> AlphaColor<T> {
     ///
     /// This function is the inverse of [`OpaqueColor::with_alpha`].
     #[must_use]
-    pub const fn split(self) -> (OpaqueColor<T>, f32) {
+    pub const fn split(self) -> (OpaqueColor<CS>, f32) {
         let (opaque, alpha) = split_alpha(self.components);
         (OpaqueColor::new(opaque), alpha)
     }
 
     #[must_use]
-    pub fn convert<U: Colorspace>(self) -> AlphaColor<U> {
-        if TypeId::of::<T>() == TypeId::of::<U>() {
+    pub fn convert<U: ColorSpace>(self) -> AlphaColor<U> {
+        if TypeId::of::<CS>() == TypeId::of::<U>() {
             AlphaColor::new(self.components)
         } else {
             let (opaque, alpha) = split_alpha(self.components);
-            let lin_rgb = T::to_linear_srgb(opaque);
+            let lin_rgb = CS::to_linear_srgb(opaque);
             AlphaColor::new(add_alpha(U::from_linear_srgb(lin_rgb), alpha))
         }
     }
 
     #[must_use]
-    pub const fn premultiply(self) -> PremulColor<T> {
+    pub const fn premultiply(self) -> PremulColor<CS> {
         let (opaque, alpha) = split_alpha(self.components);
-        PremulColor::new(add_alpha(T::LAYOUT.scale(opaque, alpha), alpha))
+        PremulColor::new(add_alpha(CS::LAYOUT.scale(opaque, alpha), alpha))
     }
 
     #[must_use]
@@ -240,41 +256,41 @@ impl<T: Colorspace> AlphaColor<T> {
     #[must_use]
     pub fn scale_chroma(self, scale: f32) -> Self {
         let (opaque, alpha) = split_alpha(self.components);
-        Self::new(add_alpha(T::scale_chroma(opaque, scale), alpha))
+        Self::new(add_alpha(CS::scale_chroma(opaque, scale), alpha))
     }
 }
 
-impl<T: Colorspace> PremulColor<T> {
+impl<CS: ColorSpace> PremulColor<CS> {
     pub const fn new(components: [f32; 4]) -> Self {
         let cs = PhantomData;
         Self { components, cs }
     }
 
     #[must_use]
-    pub fn convert<U: Colorspace>(self) -> PremulColor<U> {
-        if TypeId::of::<T>() == TypeId::of::<U>() {
+    pub fn convert<TargetCS: ColorSpace>(self) -> PremulColor<TargetCS> {
+        if TypeId::of::<CS>() == TypeId::of::<TargetCS>() {
             PremulColor::new(self.components)
-        } else if U::IS_LINEAR && T::IS_LINEAR {
+        } else if TargetCS::IS_LINEAR && CS::IS_LINEAR {
             let (multiplied, alpha) = split_alpha(self.components);
-            let lin_rgb = T::to_linear_srgb(multiplied);
-            PremulColor::new(add_alpha(U::from_linear_srgb(lin_rgb), alpha))
+            let lin_rgb = CS::to_linear_srgb(multiplied);
+            PremulColor::new(add_alpha(TargetCS::from_linear_srgb(lin_rgb), alpha))
         } else {
             self.un_premultiply().convert().premultiply()
         }
     }
 
     #[must_use]
-    pub fn un_premultiply(self) -> AlphaColor<T> {
+    pub fn un_premultiply(self) -> AlphaColor<CS> {
         let (multiplied, alpha) = split_alpha(self.components);
         let scale = if alpha == 0.0 { 1.0 } else { 1.0 / alpha };
-        AlphaColor::new(add_alpha(T::LAYOUT.scale(multiplied, scale), alpha))
+        AlphaColor::new(add_alpha(CS::LAYOUT.scale(multiplied, scale), alpha))
     }
 
     /// Interpolate colors.
     ///
     /// Note: this function doesn't fix up hue in cylindrical spaces. It is
-    /// still be useful if the hue angles are compatible, particularly if
-    /// the fixup has been applied.
+    /// still useful if the hue angles are compatible, particularly if the
+    /// fixup has been applied.
     #[must_use]
     pub fn lerp_rect(self, other: Self, t: f32) -> Self {
         self + t * (other - self)
@@ -285,7 +301,7 @@ impl<T: Colorspace> PremulColor<T> {
     /// Adjust the hue angle of `other` so that linear interpolation results in
     /// the expected hue direction.
     pub fn fixup_hues(self, other: &mut Self, direction: HueDirection) {
-        if let Some(ix) = T::LAYOUT.hue_channel() {
+        if let Some(ix) = CS::LAYOUT.hue_channel() {
             fixup_hue(self.components[ix], &mut other.components[ix], direction);
         }
     }
@@ -300,39 +316,33 @@ impl<T: Colorspace> PremulColor<T> {
     #[must_use]
     pub const fn mul_alpha(self, rhs: f32) -> Self {
         let (multiplied, alpha) = split_alpha(self.components);
-        Self::new(add_alpha(T::LAYOUT.scale(multiplied, rhs), alpha * rhs))
+        Self::new(add_alpha(CS::LAYOUT.scale(multiplied, rhs), alpha * rhs))
     }
 
     /// Difference between two colors by Euclidean metric.
     #[must_use]
     pub fn difference(self, other: Self) -> f32 {
-        let x = self.components;
-        let y = other.components;
-        let (d0, d1, d2, d3) = (x[0] - y[0], x[1] - y[1], x[2] - y[2], x[3] - y[3]);
-        (d0 * d0 + d1 * d1 + d2 * d2 + d3 * d3).sqrt()
+        let d = (self - other).components;
+        (d[0] * d[0] + d[1] * d[1] + d[2] * d[2] + d[3] * d[3]).sqrt()
     }
 }
 
 // Lossless conversion traits.
 
-impl<T: Colorspace> From<OpaqueColor<T>> for AlphaColor<T> {
-    fn from(value: OpaqueColor<T>) -> Self {
+impl<CS: ColorSpace> From<OpaqueColor<CS>> for AlphaColor<CS> {
+    fn from(value: OpaqueColor<CS>) -> Self {
         value.with_alpha(1.0)
     }
 }
 
-impl<T: Colorspace> From<OpaqueColor<T>> for PremulColor<T> {
-    fn from(value: OpaqueColor<T>) -> Self {
+impl<CS: ColorSpace> From<OpaqueColor<CS>> for PremulColor<CS> {
+    fn from(value: OpaqueColor<CS>) -> Self {
         Self::new(add_alpha(value.components, 1.0))
     }
 }
 
-// Arithmetic traits. A major motivation for providing these is to enable
-// weighted sums, which are well defined when the weights sum to 1. In
-// addition, multiplication by alpha is well defined for premultiplied
-// colors in rectangular colorspaces.
-
-impl<T: Colorspace> core::ops::Mul<f32> for OpaqueColor<T> {
+/// Multiply components by a scalar.
+impl<CS: ColorSpace> core::ops::Mul<f32> for OpaqueColor<CS> {
     type Output = Self;
 
     fn mul(self, rhs: f32) -> Self {
@@ -340,27 +350,28 @@ impl<T: Colorspace> core::ops::Mul<f32> for OpaqueColor<T> {
     }
 }
 
-impl<T: Colorspace> core::ops::Mul<OpaqueColor<T>> for f32 {
-    type Output = OpaqueColor<T>;
+/// Multiply components by a scalar.
+impl<CS: ColorSpace> core::ops::Mul<OpaqueColor<CS>> for f32 {
+    type Output = OpaqueColor<CS>;
 
-    fn mul(self, rhs: OpaqueColor<T>) -> Self::Output {
+    fn mul(self, rhs: OpaqueColor<CS>) -> Self::Output {
         rhs * self
     }
 }
 
-impl<T: Colorspace> core::ops::Div<f32> for OpaqueColor<T> {
+/// Divide components by a scalar.
+impl<CS: ColorSpace> core::ops::Div<f32> for OpaqueColor<CS> {
     type Output = Self;
 
-    #[expect(
-        clippy::suspicious_arithmetic_impl,
-        reason = "somebody please teach clippy about multiplicative inverses"
-    )]
+    // https://github.com/rust-lang/rust-clippy/issues/13652 has been filed
+    #[expect(clippy::suspicious_arithmetic_impl, reason = "multiplicative inverse")]
     fn div(self, rhs: f32) -> Self {
         self * rhs.recip()
     }
 }
 
-impl<T: Colorspace> core::ops::Add for OpaqueColor<T> {
+/// Component-wise addition of components.
+impl<CS: ColorSpace> core::ops::Add for OpaqueColor<CS> {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
@@ -370,7 +381,8 @@ impl<T: Colorspace> core::ops::Add for OpaqueColor<T> {
     }
 }
 
-impl<T: Colorspace> core::ops::Sub for OpaqueColor<T> {
+/// Component-wise subtraction of components.
+impl<CS: ColorSpace> core::ops::Sub for OpaqueColor<CS> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
@@ -380,7 +392,8 @@ impl<T: Colorspace> core::ops::Sub for OpaqueColor<T> {
     }
 }
 
-impl<T: Colorspace> core::ops::Mul<f32> for AlphaColor<T> {
+/// Multiply components by a scalar.
+impl<CS: ColorSpace> core::ops::Mul<f32> for AlphaColor<CS> {
     type Output = Self;
 
     fn mul(self, rhs: f32) -> Self {
@@ -388,27 +401,27 @@ impl<T: Colorspace> core::ops::Mul<f32> for AlphaColor<T> {
     }
 }
 
-impl<T: Colorspace> core::ops::Mul<AlphaColor<T>> for f32 {
-    type Output = AlphaColor<T>;
+/// Multiply components by a scalar.
+impl<CS: ColorSpace> core::ops::Mul<AlphaColor<CS>> for f32 {
+    type Output = AlphaColor<CS>;
 
-    fn mul(self, rhs: AlphaColor<T>) -> Self::Output {
+    fn mul(self, rhs: AlphaColor<CS>) -> Self::Output {
         rhs * self
     }
 }
 
-impl<T: Colorspace> core::ops::Div<f32> for AlphaColor<T> {
+/// Divide components by a scalar.
+impl<CS: ColorSpace> core::ops::Div<f32> for AlphaColor<CS> {
     type Output = Self;
 
-    #[expect(
-        clippy::suspicious_arithmetic_impl,
-        reason = "somebody please teach clippy about multiplicative inverses"
-    )]
+    #[expect(clippy::suspicious_arithmetic_impl, reason = "multiplicative inverse")]
     fn div(self, rhs: f32) -> Self {
         self * rhs.recip()
     }
 }
 
-impl<T: Colorspace> core::ops::Add for AlphaColor<T> {
+/// Component-wise addition of components.
+impl<CS: ColorSpace> core::ops::Add for AlphaColor<CS> {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
@@ -418,7 +431,8 @@ impl<T: Colorspace> core::ops::Add for AlphaColor<T> {
     }
 }
 
-impl<T: Colorspace> core::ops::Sub for AlphaColor<T> {
+/// Component-wise subtraction of components.
+impl<CS: ColorSpace> core::ops::Sub for AlphaColor<CS> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
@@ -428,7 +442,12 @@ impl<T: Colorspace> core::ops::Sub for AlphaColor<T> {
     }
 }
 
-impl<T: Colorspace> core::ops::Mul<f32> for PremulColor<T> {
+/// Multiply components by a scalar.
+///
+/// For rectangular color spaces, this is equivalent to multiplying
+/// alpha, but for cylindrical color spaces, [`PremulColor::mul_alpha`]
+/// is the preferred method.
+impl<CS: ColorSpace> core::ops::Mul<f32> for PremulColor<CS> {
     type Output = Self;
 
     fn mul(self, rhs: f32) -> Self {
@@ -436,27 +455,27 @@ impl<T: Colorspace> core::ops::Mul<f32> for PremulColor<T> {
     }
 }
 
-impl<T: Colorspace> core::ops::Mul<PremulColor<T>> for f32 {
-    type Output = PremulColor<T>;
+/// Multiply components by a scalar.
+impl<CS: ColorSpace> core::ops::Mul<PremulColor<CS>> for f32 {
+    type Output = PremulColor<CS>;
 
-    fn mul(self, rhs: PremulColor<T>) -> Self::Output {
+    fn mul(self, rhs: PremulColor<CS>) -> Self::Output {
         rhs * self
     }
 }
 
-impl<T: Colorspace> core::ops::Div<f32> for PremulColor<T> {
+/// Divide components by a scalar.
+impl<CS: ColorSpace> core::ops::Div<f32> for PremulColor<CS> {
     type Output = Self;
 
-    #[expect(
-        clippy::suspicious_arithmetic_impl,
-        reason = "somebody please teach clippy about multiplicative inverses"
-    )]
+    #[expect(clippy::suspicious_arithmetic_impl, reason = "multiplicative inverse")]
     fn div(self, rhs: f32) -> Self {
         self * rhs.recip()
     }
 }
 
-impl<T: Colorspace> core::ops::Add for PremulColor<T> {
+/// Component-wise addition of components.
+impl<CS: ColorSpace> core::ops::Add for PremulColor<CS> {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
@@ -466,7 +485,8 @@ impl<T: Colorspace> core::ops::Add for PremulColor<T> {
     }
 }
 
-impl<T: Colorspace> core::ops::Sub for PremulColor<T> {
+/// Component-wise subtraction of components.
+impl<CS: ColorSpace> core::ops::Sub for PremulColor<CS> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
@@ -477,54 +497,59 @@ impl<T: Colorspace> core::ops::Sub for PremulColor<T> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{fixup_hue, HueDirection};
 
     #[test]
-    fn test_hue_fixup() {
+    fn hue_fixup() {
         // Verify that the hue arc matches the spec for all hues specified
         // within [0,360).
         for h1 in [0.0, 10.0, 180.0, 190.0, 350.0] {
             for h2 in [0.0, 10.0, 180.0, 190.0, 350.0] {
                 let dh = h2 - h1;
-                let mut fixed_h2 = h2;
-                fixup_hue(h1, &mut fixed_h2, HueDirection::Shorter);
-                let (mut spec_h1, mut spec_h2) = (h1, h2);
-                if dh > 180.0 {
-                    spec_h1 += 360.0;
-                } else if dh < -180.0 {
-                    spec_h2 += 360.0;
+                {
+                    let mut fixed_h2 = h2;
+                    fixup_hue(h1, &mut fixed_h2, HueDirection::Shorter);
+                    let (mut spec_h1, mut spec_h2) = (h1, h2);
+                    if dh > 180.0 {
+                        spec_h1 += 360.0;
+                    } else if dh < -180.0 {
+                        spec_h2 += 360.0;
+                    }
+                    assert_eq!(fixed_h2 - h1, spec_h2 - spec_h1);
                 }
-                assert_eq!(fixed_h2 - h1, spec_h2 - spec_h1);
 
-                fixed_h2 = h2;
-                fixup_hue(h1, &mut fixed_h2, HueDirection::Longer);
-                spec_h1 = h1;
-                spec_h2 = h2;
-                if 0.0 < dh && dh < 180.0 {
-                    spec_h1 += 360.0;
-                } else if -180.0 < dh && dh <= 0.0 {
-                    spec_h2 += 360.0;
+                {
+                    let mut fixed_h2 = h2;
+                    fixup_hue(h1, &mut fixed_h2, HueDirection::Longer);
+                    let (mut spec_h1, mut spec_h2) = (h1, h2);
+                    if 0.0 < dh && dh < 180.0 {
+                        spec_h1 += 360.0;
+                    } else if -180.0 < dh && dh <= 0.0 {
+                        spec_h2 += 360.0;
+                    }
+                    assert_eq!(fixed_h2 - h1, spec_h2 - spec_h1);
                 }
-                assert_eq!(fixed_h2 - h1, spec_h2 - spec_h1);
 
-                fixed_h2 = h2;
-                fixup_hue(h1, &mut fixed_h2, HueDirection::Increasing);
-                spec_h1 = h1;
-                spec_h2 = h2;
-                if dh < 0.0 {
-                    spec_h2 += 360.0;
+                {
+                    let mut fixed_h2 = h2;
+                    fixup_hue(h1, &mut fixed_h2, HueDirection::Increasing);
+                    let (spec_h1, mut spec_h2) = (h1, h2);
+                    if dh < 0.0 {
+                        spec_h2 += 360.0;
+                    }
+                    assert_eq!(fixed_h2 - h1, spec_h2 - spec_h1);
                 }
-                assert_eq!(fixed_h2 - h1, spec_h2 - spec_h1);
 
-                fixed_h2 = h2;
-                fixup_hue(h1, &mut fixed_h2, HueDirection::Decreasing);
-                spec_h1 = h1;
-                spec_h2 = h2;
-                if dh > 0.0 {
-                    spec_h1 += 360.0;
+                {
+                    let mut fixed_h2 = h2;
+                    fixup_hue(h1, &mut fixed_h2, HueDirection::Decreasing);
+                    let (mut spec_h1, spec_h2) = (h1, h2);
+                    if dh > 0.0 {
+                        spec_h1 += 360.0;
+                    }
+                    assert_eq!(fixed_h2 - h1, spec_h2 - spec_h1);
                 }
-                assert_eq!(fixed_h2 - h1, spec_h2 - spec_h1);
             }
         }
     }

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -174,7 +174,7 @@ impl<CS: ColorSpace> OpaqueColor<CS> {
 
     /// Scale the chroma by the given amount.
     ///
-    /// See [`Colorspace::scale_chroma`] for more details.
+    /// See [`ColorSpace::scale_chroma`] for more details.
     #[must_use]
     pub fn scale_chroma(self, scale: f32) -> Self {
         Self::new(CS::scale_chroma(self.components, scale))
@@ -252,7 +252,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
 
     /// Scale the chroma by the given amount.
     ///
-    /// See [`Colorspace::scale_chroma`] for more details.
+    /// See [`ColorSpace::scale_chroma`] for more details.
     #[must_use]
     pub fn scale_chroma(self, scale: f32) -> Self {
         let (opaque, alpha) = split_alpha(self.components);

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -24,7 +24,7 @@ use crate::floatfuncs::FloatFuncs;
 pub trait ColorSpace: Clone + Copy + 'static {
     /// Whether the color space is linear.
     ///
-    /// Calculations in linear colors paces can sometimes be simplified,
+    /// Calculations in linear color spaces can sometimes be simplified,
     /// for example it is not necessary to undo premultiplication when
     /// converting.
     const IS_LINEAR: bool = false;

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -8,35 +8,35 @@ use crate::{matmul, tagged::ColorspaceTag};
 #[cfg(all(not(feature = "std"), not(test)))]
 use crate::floatfuncs::FloatFuncs;
 
-/// The main trait for colorspaces.
+/// The main trait for color spaces.
 ///
 /// This can be implemented by clients for conversions in and out of
-/// new colorspaces. It is expected to be a zero-sized type.
+/// new color spaces. It is expected to be a zero-sized type.
 ///
-/// The linear sRGB colorspace is central, and other colorspaces are
-/// defined as conversions in and out of that. A colorspace does not
+/// The linear sRGB color space is central, and other color spaces are
+/// defined as conversions in and out of that. A color space does not
 /// explicitly define a gamut, so generally conversions will succeed
 /// and round-trip, subject to numerical precision.
 ///
 /// White point is not explicitly represented. For color spaces with a
 /// white point other than D65 (the native white point for sRGB), use
 /// a linear Bradford chromatic adaptation, following CSS Color 4.
-pub trait Colorspace: Clone + Copy + 'static {
-    /// Whether the colorspace is linear.
+pub trait ColorSpace: Clone + Copy + 'static {
+    /// Whether the color space is linear.
     ///
-    /// Calculations in linear colorspaces can sometimes be simplified,
+    /// Calculations in linear colors paces can sometimes be simplified,
     /// for example it is not necessary to undo premultiplication when
     /// converting.
     const IS_LINEAR: bool = false;
 
-    /// The layout of the colorspace.
+    /// The layout of the color space.
     ///
     /// The layout primarily identifies the hue channel for cylindrical
-    /// colorspaces, which is important because hue is not premultiplied.
-    const LAYOUT: ColorspaceLayout = ColorspaceLayout::Rectangular;
+    /// color spaces, which is important because hue is not premultiplied.
+    const LAYOUT: ColorSpaceLayout = ColorSpaceLayout::Rectangular;
 
-    /// The tag corresponding to this colorspace, if a matching tag exists.
-    const CS_TAG: Option<ColorspaceTag> = None;
+    /// The tag corresponding to this color space, if a matching tag exists.
+    const TAG: Option<ColorspaceTag> = None;
 
     /// Convert an opaque color to linear sRGB.
     ///
@@ -50,8 +50,8 @@ pub trait Colorspace: Clone + Copy + 'static {
 
     /// Scale the chroma by the given amount.
     ///
-    /// In colorspaces with a natural representation of chroma, scale
-    /// directly. In other colorspaces, equivalent results as scaling
+    /// In color spaces with a natural representation of chroma, scale
+    /// directly. In other color spaces, equivalent results as scaling
     /// chroma in Oklab.
     fn scale_chroma(src: [f32; 3], scale: f32) -> [f32; 3] {
         let rgb = Self::to_linear_srgb(src);
@@ -60,16 +60,16 @@ pub trait Colorspace: Clone + Copy + 'static {
     }
 }
 
-/// The layout of a colorspace, particularly the hue channel.
+/// The layout of a color space, particularly the hue channel.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[non_exhaustive]
-pub enum ColorspaceLayout {
+pub enum ColorSpaceLayout {
     Rectangular,
     HueFirst,
     HueThird,
 }
 
-impl ColorspaceLayout {
+impl ColorSpaceLayout {
     /// Multiply all components except for hue by scale.
     ///
     /// This function is used for both premultiplying and un-premultiplying. See
@@ -98,10 +98,10 @@ impl ColorspaceLayout {
 #[derive(Clone, Copy, Debug)]
 pub struct LinearSrgb;
 
-impl Colorspace for LinearSrgb {
+impl ColorSpace for LinearSrgb {
     const IS_LINEAR: bool = true;
 
-    const CS_TAG: Option<ColorspaceTag> = Some(ColorspaceTag::LinearSrgb);
+    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::LinearSrgb);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         src
@@ -144,8 +144,8 @@ fn lin_to_srgb(x: f32) -> f32 {
     }
 }
 
-impl Colorspace for Srgb {
-    const CS_TAG: Option<ColorspaceTag> = Some(ColorspaceTag::Srgb);
+impl ColorSpace for Srgb {
+    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::Srgb);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         src.map(srgb_to_lin)
@@ -159,8 +159,8 @@ impl Colorspace for Srgb {
 #[derive(Clone, Copy, Debug)]
 pub struct DisplayP3;
 
-impl Colorspace for DisplayP3 {
-    const CS_TAG: Option<ColorspaceTag> = Some(ColorspaceTag::DisplayP3);
+impl ColorSpace for DisplayP3 {
+    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::DisplayP3);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         const LINEAR_DISPLAYP3_TO_SRGB: [[f32; 3]; 3] = [
@@ -184,10 +184,10 @@ impl Colorspace for DisplayP3 {
 #[derive(Clone, Copy, Debug)]
 pub struct XyzD65;
 
-impl Colorspace for XyzD65 {
+impl ColorSpace for XyzD65 {
     const IS_LINEAR: bool = true;
 
-    const CS_TAG: Option<ColorspaceTag> = Some(ColorspaceTag::XyzD65);
+    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::XyzD65);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         const XYZ_TO_LINEAR_SRGB: [[f32; 3]; 3] = [
@@ -211,7 +211,9 @@ impl Colorspace for XyzD65 {
 #[derive(Clone, Copy, Debug)]
 pub struct Oklab;
 
-// Matrices taken from Oklab blog post, precision reduced to f32
+// Matrices taken from [Oklab] blog post, precision reduced to f32
+//
+// [Oklab]: https://bottosson.github.io/posts/oklab/
 const OKLAB_LAB_TO_LMS: [[f32; 3]; 3] = [
     [1.0, 0.396_337_78, 0.215_803_76],
     [1.0, -0.105_561_346, -0.063_854_17],
@@ -236,8 +238,8 @@ const OKLAB_LMS_TO_LAB: [[f32; 3]; 3] = [
     [0.025_904_037, 0.782_771_77, -0.808_675_77],
 ];
 
-impl Colorspace for Oklab {
-    const CS_TAG: Option<ColorspaceTag> = Some(ColorspaceTag::Oklab);
+impl ColorSpace for Oklab {
+    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::Oklab);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         let lms = matmul(&OKLAB_LAB_TO_LMS, src).map(|x| x * x * x);
@@ -257,10 +259,10 @@ impl Colorspace for Oklab {
 #[derive(Clone, Copy, Debug)]
 pub struct Oklch;
 
-impl Colorspace for Oklch {
-    const CS_TAG: Option<ColorspaceTag> = Some(ColorspaceTag::Oklch);
+impl ColorSpace for Oklch {
+    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::Oklch);
 
-    const LAYOUT: ColorspaceLayout = ColorspaceLayout::HueThird;
+    const LAYOUT: ColorSpaceLayout = ColorSpaceLayout::HueThird;
 
     fn from_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         let lab = Oklab::from_linear_srgb(src);

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -3,7 +3,7 @@
 
 use core::f32;
 
-use crate::{matmul, tagged::ColorspaceTag};
+use crate::{matmul, tagged::ColorSpaceTag};
 
 #[cfg(all(not(feature = "std"), not(test)))]
 use crate::floatfuncs::FloatFuncs;
@@ -36,7 +36,7 @@ pub trait ColorSpace: Clone + Copy + 'static {
     const LAYOUT: ColorSpaceLayout = ColorSpaceLayout::Rectangular;
 
     /// The tag corresponding to this color space, if a matching tag exists.
-    const TAG: Option<ColorspaceTag> = None;
+    const TAG: Option<ColorSpaceTag> = None;
 
     /// Convert an opaque color to linear sRGB.
     ///
@@ -101,7 +101,7 @@ pub struct LinearSrgb;
 impl ColorSpace for LinearSrgb {
     const IS_LINEAR: bool = true;
 
-    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::LinearSrgb);
+    const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::LinearSrgb);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         src
@@ -145,7 +145,7 @@ fn lin_to_srgb(x: f32) -> f32 {
 }
 
 impl ColorSpace for Srgb {
-    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::Srgb);
+    const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::Srgb);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         src.map(srgb_to_lin)
@@ -160,7 +160,7 @@ impl ColorSpace for Srgb {
 pub struct DisplayP3;
 
 impl ColorSpace for DisplayP3 {
-    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::DisplayP3);
+    const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::DisplayP3);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         const LINEAR_DISPLAYP3_TO_SRGB: [[f32; 3]; 3] = [
@@ -187,7 +187,7 @@ pub struct XyzD65;
 impl ColorSpace for XyzD65 {
     const IS_LINEAR: bool = true;
 
-    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::XyzD65);
+    const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::XyzD65);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         const XYZ_TO_LINEAR_SRGB: [[f32; 3]; 3] = [
@@ -239,7 +239,7 @@ const OKLAB_LMS_TO_LAB: [[f32; 3]; 3] = [
 ];
 
 impl ColorSpace for Oklab {
-    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::Oklab);
+    const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::Oklab);
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         let lms = matmul(&OKLAB_LAB_TO_LMS, src).map(|x| x * x * x);
@@ -260,7 +260,7 @@ impl ColorSpace for Oklab {
 pub struct Oklch;
 
 impl ColorSpace for Oklch {
-    const TAG: Option<ColorspaceTag> = Some(ColorspaceTag::Oklch);
+    const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::Oklch);
 
     const LAYOUT: ColorSpaceLayout = ColorSpaceLayout::HueThird;
 

--- a/color/src/css.rs
+++ b/color/src/css.rs
@@ -5,12 +5,12 @@
 
 use crate::{
     color::{add_alpha, fixup_hues_for_interpolate, split_alpha},
-    AlphaColor, Bitset, ColorSpace, ColorSpaceLayout, ColorspaceTag, HueDirection, TaggedColor,
+    AlphaColor, Bitset, ColorSpace, ColorSpaceLayout, ColorSpaceTag, HueDirection, TaggedColor,
 };
 
 #[derive(Clone, Copy, Debug)]
 pub struct CssColor {
-    pub cs: ColorspaceTag,
+    pub cs: ColorSpaceTag,
     /// A bitmask of missing components.
     pub missing: Bitset,
     pub components: [f32; 4],
@@ -26,7 +26,7 @@ pub struct Interpolator {
     alpha1: f32,
     delta_premul: [f32; 3],
     alpha2: f32,
-    cs: ColorspaceTag,
+    cs: ColorSpaceTag,
     missing: Bitset,
 }
 
@@ -58,7 +58,7 @@ impl CssColor {
     }
 
     #[must_use]
-    pub fn convert(self, cs: ColorspaceTag) -> Self {
+    pub fn convert(self, cs: ColorSpaceTag) -> Self {
         if self.cs == cs {
             // Note: §12 suggests that changing powerless to missing happens
             // even when the color is already in the interpolation color space,
@@ -105,7 +105,7 @@ impl CssColor {
 
     /// Scale the chroma by the given amount.
     ///
-    /// See [`Colorspace::scale_chroma`] for more details.
+    /// See [`ColorSpace::scale_chroma`] for more details.
     #[must_use]
     pub fn scale_chroma(self, scale: f32) -> Self {
         let (opaque, alpha) = split_alpha(self.components);
@@ -157,7 +157,7 @@ impl CssColor {
     pub fn interpolate(
         self,
         other: Self,
-        cs: ColorspaceTag,
+        cs: ColorSpaceTag,
         direction: HueDirection,
     ) -> Interpolator {
         let mut a = self.convert(cs);
@@ -199,7 +199,7 @@ impl CssColor {
     /// Blending semi-transparent colors will reduce contrast, and that
     /// should also be taken into account.
     pub fn relative_luminance(self) -> f32 {
-        let rgb = self.convert(ColorspaceTag::LinearSrgb).components;
+        let rgb = self.convert(ColorSpaceTag::LinearSrgb).components;
         0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]
     }
 }

--- a/color/src/floatfuncs.rs
+++ b/color/src/floatfuncs.rs
@@ -7,7 +7,7 @@
 macro_rules! define_float_funcs {
     ($(
         fn $name:ident(self $(,$arg:ident: $arg_ty:ty)*) -> $ret:ty
-        => $lname:ident/$lfname:ident;
+        => $lfname:ident;
     )+) => {
 
         /// Since core doesn't depend upon libm, this provides libm implementations
@@ -35,17 +35,17 @@ macro_rules! define_float_funcs {
 }
 
 define_float_funcs! {
-    fn abs(self) -> Self => fabs/fabsf;
-    fn atan2(self, other: Self) -> Self => atan2/atan2f;
-    fn cbrt(self) -> Self => cbrt/cbrtf;
-    fn ceil(self) -> Self => ceil/ceilf;
-    fn copysign(self, sign: Self) -> Self => copysign/copysignf;
-    fn floor(self) -> Self => floor/floorf;
-    fn hypot(self, other: Self) -> Self => hypot/hypotf;
+    fn abs(self) -> Self => fabsf;
+    fn atan2(self, other: Self) -> Self => atan2f;
+    fn cbrt(self) -> Self => cbrtf;
+    fn ceil(self) -> Self => ceilf;
+    fn copysign(self, sign: Self) -> Self => copysignf;
+    fn floor(self) -> Self => floorf;
+    fn hypot(self, other: Self) -> Self => hypotf;
     // Note: powi is missing because its libm implementation is not efficient
-    fn powf(self, n: Self) -> Self => pow/powf;
-    fn round(self) -> Self => round/roundf;
-    fn sin_cos(self) -> (Self, Self) => sincos/sincosf;
-    fn sqrt(self) -> Self => sqrt/sqrtf;
-    fn trunc(self) -> Self => trunc/truncf;
+    fn powf(self, n: Self) -> Self => powf;
+    fn round(self) -> Self => roundf;
+    fn sin_cos(self) -> (Self, Self) => sincosf;
+    fn sqrt(self) -> Self => sqrtf;
+    fn trunc(self) -> Self => truncf;
 }

--- a/color/src/gradient.rs
+++ b/color/src/gradient.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Color Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::{ColorSpace, ColorspaceTag, CssColor, HueDirection, Interpolator, Oklab, PremulColor};
+use crate::{ColorSpace, ColorSpaceTag, CssColor, HueDirection, Interpolator, Oklab, PremulColor};
 
 #[expect(missing_debug_implementations, reason = "it's an iterator")]
 pub struct GradientIter<CS: ColorSpace> {
@@ -19,7 +19,7 @@ pub struct GradientIter<CS: ColorSpace> {
 pub fn gradient<CS: ColorSpace>(
     mut color0: CssColor,
     mut color1: CssColor,
-    interp_cs: ColorspaceTag,
+    interp_cs: ColorSpaceTag,
     direction: HueDirection,
     tolerance: f32,
 ) -> GradientIter<CS> {

--- a/color/src/gradient.rs
+++ b/color/src/gradient.rs
@@ -1,10 +1,10 @@
 // Copyright 2024 the Color Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::{Colorspace, ColorspaceTag, CssColor, HueDirection, Interpolator, Oklab, PremulColor};
+use crate::{ColorSpace, ColorspaceTag, CssColor, HueDirection, Interpolator, Oklab, PremulColor};
 
 #[expect(missing_debug_implementations, reason = "it's an iterator")]
-pub struct GradientIter<CS: Colorspace> {
+pub struct GradientIter<CS: ColorSpace> {
     interpolator: Interpolator,
     // This is in deltaEOK units
     tolerance: f32,
@@ -16,7 +16,7 @@ pub struct GradientIter<CS: Colorspace> {
     end_color: PremulColor<CS>,
 }
 
-pub fn gradient<CS: Colorspace>(
+pub fn gradient<CS: ColorSpace>(
     mut color0: CssColor,
     mut color1: CssColor,
     interp_cs: ColorspaceTag,
@@ -44,7 +44,7 @@ pub fn gradient<CS: Colorspace>(
     }
 }
 
-impl<CS: Colorspace> Iterator for GradientIter<CS> {
+impl<CS: ColorSpace> Iterator for GradientIter<CS> {
     type Item = (f32, PremulColor<CS>);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -41,7 +41,7 @@ pub use colorspace::{
 pub use css::{CssColor, Interpolator};
 pub use gradient::{gradient, GradientIter};
 pub use parse::{parse_color, Error};
-pub use tagged::{ColorspaceTag, TaggedColor};
+pub use tagged::{ColorSpaceTag, TaggedColor};
 
 const fn u8_to_f32(x: u32) -> f32 {
     x as f32 * (1.0 / 255.0)

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -36,7 +36,7 @@ mod floatfuncs;
 pub use bitset::Bitset;
 pub use color::{AlphaColor, HueDirection, OpaqueColor, PremulColor};
 pub use colorspace::{
-    Colorspace, ColorspaceLayout, DisplayP3, LinearSrgb, Oklab, Oklch, Srgb, XyzD65,
+    ColorSpace, ColorSpaceLayout, DisplayP3, LinearSrgb, Oklab, Oklch, Srgb, XyzD65,
 };
 pub use css::{CssColor, Interpolator};
 pub use gradient::{gradient, GradientIter};

--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -6,7 +6,7 @@
 use core::f64;
 use core::str::FromStr;
 
-use crate::{AlphaColor, Bitset, ColorspaceTag, CssColor, Srgb, TaggedColor};
+use crate::{AlphaColor, Bitset, ColorSpaceTag, CssColor, Srgb, TaggedColor};
 
 // TODO: proper error type, maybe include string offset
 pub type Error = &'static str;
@@ -30,7 +30,7 @@ enum Value<'a> {
     clippy::cast_possible_truncation,
     reason = "deliberate choice of f32 for colors"
 )]
-fn color_from_components(components: [Option<f64>; 4], cs: ColorspaceTag) -> CssColor {
+fn color_from_components(components: [Option<f64>; 4], cs: ColorSpaceTag) -> CssColor {
     let mut missing = Bitset::default();
     for (i, component) in components.iter().enumerate() {
         if component.is_none() {
@@ -285,7 +285,7 @@ impl<'a> Parser<'a> {
         if !self.ch(b')') {
             return Err("expected closing parenthesis");
         }
-        Ok(color_from_components([r, g, b, alpha], ColorspaceTag::Srgb))
+        Ok(color_from_components([r, g, b, alpha], ColorSpaceTag::Srgb))
     }
 
     fn optional_alpha(&mut self) -> Result<Option<f64>, Error> {
@@ -311,7 +311,7 @@ impl<'a> Parser<'a> {
         }
         Ok(color_from_components(
             [l, a, b, alpha],
-            ColorspaceTag::Oklab,
+            ColorSpaceTag::Oklab,
         ))
     }
 
@@ -328,7 +328,7 @@ impl<'a> Parser<'a> {
         }
         Ok(color_from_components(
             [l, c, h, alpha],
-            ColorspaceTag::Oklch,
+            ColorSpaceTag::Oklch,
         ))
     }
 
@@ -341,10 +341,10 @@ impl<'a> Parser<'a> {
             return Err("expected identifier for colorspace");
         };
         let cs = match id {
-            "srgb" => ColorspaceTag::Srgb,
-            "srgb-linear" => ColorspaceTag::LinearSrgb,
-            "display-p3" => ColorspaceTag::DisplayP3,
-            "xyz" | "xyz-d65" => ColorspaceTag::XyzD65,
+            "srgb" => ColorSpaceTag::Srgb,
+            "srgb-linear" => ColorSpaceTag::LinearSrgb,
+            "display-p3" => ColorSpaceTag::DisplayP3,
+            "xyz" | "xyz-d65" => ColorSpaceTag::XyzD65,
             _ => return Err("unknown colorspace"),
         };
         let r = self.scaled_component(1., 0.01)?;
@@ -377,7 +377,7 @@ pub fn parse_color(s: &str) -> Result<CssColor, Error> {
             "rgb" | "rgba" => parser.rgb(),
             "oklab" => parser.oklab(),
             "oklch" => parser.oklch(),
-            "transparent" => Ok(color_from_components([Some(0.); 4], ColorspaceTag::Srgb)),
+            "transparent" => Ok(color_from_components([Some(0.); 4], ColorSpaceTag::Srgb)),
             "color" => parser.color(),
             _ => Err("unknown identifier"),
         }
@@ -425,7 +425,7 @@ const fn color_from_4bit_hex(components: [u8; 8]) -> AlphaColor<Srgb> {
     AlphaColor::from_rgba8(r0 << 4 | r1, g0 << 4 | g1, b0 << 4 | b1, a0 << 4 | a1)
 }
 
-impl FromStr for ColorspaceTag {
+impl FromStr for ColorSpaceTag {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/color/src/serialize.rs
+++ b/color/src/serialize.rs
@@ -5,7 +5,7 @@
 
 use core::fmt::{Formatter, Result};
 
-use crate::{ColorspaceTag, CssColor};
+use crate::{ColorSpaceTag, CssColor};
 
 fn write_scaled_component(
     color: &CssColor,
@@ -57,7 +57,7 @@ fn write_color_function(color: &CssColor, name: &str, f: &mut Formatter<'_>) -> 
 impl core::fmt::Display for CssColor {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self.cs {
-            ColorspaceTag::Srgb => {
+            ColorSpaceTag::Srgb => {
                 // A case can be made this isn't the best serialization in general,
                 // because CSS parsing of out-of-gamut components will clamp.
                 let opt_a = if self.components[3] < 1.0 { "a" } else { "" };
@@ -74,13 +74,13 @@ impl core::fmt::Display for CssColor {
                 }
                 write!(f, ")")
             }
-            ColorspaceTag::LinearSrgb => write_color_function(self, "srgb-linear", f),
-            ColorspaceTag::DisplayP3 => write_color_function(self, "display-p3", f),
-            ColorspaceTag::XyzD65 => write_color_function(self, "xyz", f),
-            ColorspaceTag::Lab => write_modern_function(self, "lab", f),
-            ColorspaceTag::Lch => write_modern_function(self, "lch", f),
-            ColorspaceTag::Oklab => write_modern_function(self, "oklab", f),
-            ColorspaceTag::Oklch => write_modern_function(self, "oklch", f),
+            ColorSpaceTag::LinearSrgb => write_color_function(self, "srgb-linear", f),
+            ColorSpaceTag::DisplayP3 => write_color_function(self, "display-p3", f),
+            ColorSpaceTag::XyzD65 => write_color_function(self, "xyz", f),
+            ColorSpaceTag::Lab => write_modern_function(self, "lab", f),
+            ColorSpaceTag::Lch => write_modern_function(self, "lch", f),
+            ColorSpaceTag::Oklab => write_modern_function(self, "oklab", f),
+            ColorSpaceTag::Oklch => write_modern_function(self, "oklch", f),
             _ => todo!(),
         }
     }

--- a/color/src/tagged.rs
+++ b/color/src/tagged.rs
@@ -9,7 +9,7 @@ use crate::{
     XyzD65,
 };
 
-/// The colo rspace tag for tagged colors.
+/// The color space tag for tagged colors.
 ///
 /// This represents a fixed set of known color spaces. The set is
 /// based on the CSS Color 4 spec, but might also extend to a small
@@ -20,7 +20,7 @@ use crate::{
 /// Note: when adding an RGB-like color space, add to `same_analogous`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[non_exhaustive]
-pub enum ColorspaceTag {
+pub enum ColorSpaceTag {
     Srgb,
     LinearSrgb,
     Lab,
@@ -37,11 +37,11 @@ pub enum ColorspaceTag {
 /// [`CssColor`][crate::css::CssColor].
 #[derive(Clone, Copy, Debug)]
 pub struct TaggedColor {
-    pub cs: ColorspaceTag,
+    pub cs: ColorSpaceTag,
     pub components: [f32; 4],
 }
 
-impl ColorspaceTag {
+impl ColorSpaceTag {
     pub(crate) fn layout(self) -> ColorSpaceLayout {
         match self {
             Self::Lch | Self::Oklch => ColorSpaceLayout::HueThird,
@@ -54,7 +54,7 @@ impl ColorspaceTag {
     // in that case we wouldn't do the conversion, so this function is not
     // guaranteed to return the correct answer in those cases.
     pub(crate) fn same_analogous(self, other: Self) -> bool {
-        use ColorspaceTag::*;
+        use ColorSpaceTag::*;
         matches!(
             (self, other),
             (
@@ -66,7 +66,7 @@ impl ColorspaceTag {
     }
 
     pub(crate) fn l_missing(self, missing: Bitset) -> bool {
-        use ColorspaceTag::*;
+        use ColorSpaceTag::*;
         match self {
             Lab | Lch | Oklab | Oklch => missing.contains(0),
             Hsl => missing.contains(2),
@@ -75,7 +75,7 @@ impl ColorspaceTag {
     }
 
     pub(crate) fn set_l_missing(self, missing: &mut Bitset, components: &mut [f32; 4]) {
-        use ColorspaceTag::*;
+        use ColorSpaceTag::*;
         match self {
             Lab | Lch | Oklab | Oklch => {
                 missing.set(0);
@@ -90,7 +90,7 @@ impl ColorspaceTag {
     }
 
     pub(crate) fn c_missing(self, missing: Bitset) -> bool {
-        use ColorspaceTag::*;
+        use ColorSpaceTag::*;
         match self {
             Lab | Lch | Oklab | Oklch | Hsl => missing.contains(1),
             _ => false,
@@ -98,7 +98,7 @@ impl ColorspaceTag {
     }
 
     pub(crate) fn set_c_missing(self, missing: &mut Bitset, components: &mut [f32; 4]) {
-        use ColorspaceTag::*;
+        use ColorSpaceTag::*;
         match self {
             Lab | Lch | Oklab | Oklch | Hsl => {
                 missing.set(1);
@@ -147,7 +147,7 @@ impl ColorspaceTag {
 
     /// Scale the chroma by the given amount.
     ///
-    /// See [`Colorspace::scale_chroma`] for more details.
+    /// See [`ColorSpace::scale_chroma`] for more details.
     pub fn scale_chroma(self, src: [f32; 3], scale: f32) -> [f32; 3] {
         match self {
             Self::LinearSrgb => LinearSrgb::scale_chroma(src, scale),
@@ -163,7 +163,7 @@ impl ColorspaceTag {
 }
 
 impl TaggedColor {
-    pub fn from_linear_srgb(rgba: [f32; 4], cs: ColorspaceTag) -> Self {
+    pub fn from_linear_srgb(rgba: [f32; 4], cs: ColorSpaceTag) -> Self {
         let (rgb, alpha) = split_alpha(rgba);
         let opaque = cs.from_linear_srgb(rgb);
         let components = add_alpha(opaque, alpha);
@@ -179,7 +179,7 @@ impl TaggedColor {
         } else {
             let components = color.convert::<LinearSrgb>().components;
             Self {
-                cs: ColorspaceTag::LinearSrgb,
+                cs: ColorSpaceTag::LinearSrgb,
                 components,
             }
         }
@@ -197,7 +197,7 @@ impl TaggedColor {
     }
 
     #[must_use]
-    pub fn convert(self, cs: ColorspaceTag) -> Self {
+    pub fn convert(self, cs: ColorSpaceTag) -> Self {
         if self.cs == cs {
             self
         } else {

--- a/color/src/tagged.rs
+++ b/color/src/tagged.rs
@@ -1,23 +1,23 @@
 // Copyright 2024 the Color Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Colors with runtime choice of colorspace.
+//! Colors with runtime choice of color space.
 
 use crate::{
     color::{add_alpha, split_alpha},
-    AlphaColor, Bitset, Colorspace, ColorspaceLayout, DisplayP3, LinearSrgb, Oklab, Oklch, Srgb,
+    AlphaColor, Bitset, ColorSpace, ColorSpaceLayout, DisplayP3, LinearSrgb, Oklab, Oklch, Srgb,
     XyzD65,
 };
 
-/// The colorspace tag for tagged colors.
+/// The colo rspace tag for tagged colors.
 ///
-/// This represents a fixed set of known colorspaces. The set is
+/// This represents a fixed set of known color spaces. The set is
 /// based on the CSS Color 4 spec, but might also extend to a small
-/// set of colorspaces used in 3D graphics.
+/// set of color spaces used in 3D graphics.
 ///
 /// Note: this has some tags not yet implemented.
 ///
-/// Note: when adding an RGB-like colorspace, add to `same_analogous`.
+/// Note: when adding an RGB-like color space, add to `same_analogous`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[non_exhaustive]
 pub enum ColorspaceTag {
@@ -33,7 +33,7 @@ pub enum ColorspaceTag {
     XyzD65,
 }
 
-/// A color with a runtime colorspace tag. This type will likely get merged with
+/// A color with a runtime color space tag. This type will likely get merged with
 /// [`CssColor`][crate::css::CssColor].
 #[derive(Clone, Copy, Debug)]
 pub struct TaggedColor {
@@ -42,15 +42,15 @@ pub struct TaggedColor {
 }
 
 impl ColorspaceTag {
-    pub(crate) fn layout(self) -> ColorspaceLayout {
+    pub(crate) fn layout(self) -> ColorSpaceLayout {
         match self {
-            Self::Lch | Self::Oklch => ColorspaceLayout::HueThird,
-            Self::Hsl | Self::Hwb => ColorspaceLayout::HueFirst,
-            _ => ColorspaceLayout::Rectangular,
+            Self::Lch | Self::Oklch => ColorSpaceLayout::HueThird,
+            Self::Hsl | Self::Hwb => ColorSpaceLayout::HueFirst,
+            _ => ColorSpaceLayout::Rectangular,
         }
     }
 
-    // Note: if colorspaces are the same, then they're also analogous, but
+    // Note: if color spaces are the same, then they're also analogous, but
     // in that case we wouldn't do the conversion, so this function is not
     // guaranteed to return the correct answer in those cases.
     pub(crate) fn same_analogous(self, other: Self) -> bool {
@@ -170,8 +170,8 @@ impl TaggedColor {
         Self { cs, components }
     }
 
-    pub fn from_alpha_color<T: Colorspace>(color: AlphaColor<T>) -> Self {
-        if let Some(cs) = T::CS_TAG {
+    pub fn from_alpha_color<CS: ColorSpace>(color: AlphaColor<CS>) -> Self {
+        if let Some(cs) = CS::TAG {
             Self {
                 cs,
                 components: color.components,
@@ -185,13 +185,13 @@ impl TaggedColor {
         }
     }
 
-    pub fn to_alpha_color<T: Colorspace>(&self) -> AlphaColor<T> {
-        if T::CS_TAG == Some(self.cs) {
+    pub fn to_alpha_color<CS: ColorSpace>(&self) -> AlphaColor<CS> {
+        if CS::TAG == Some(self.cs) {
             AlphaColor::new(self.components)
         } else {
             let (opaque, alpha) = split_alpha(self.components);
             let rgb = self.cs.to_linear_srgb(opaque);
-            let components = add_alpha(T::from_linear_srgb(rgb), alpha);
+            let components = add_alpha(CS::from_linear_srgb(rgb), alpha);
             AlphaColor::new(components)
         }
     }


### PR DESCRIPTION
In response to feedback on #3.

One comment that was not addressed was direct conversion between color spaces, as opposed to always going through linear rgb.