### PR TITLE
Move conversion logic into ColorSpace

### DIFF
--- a/color/examples/gradient.rs
+++ b/color/examples/gradient.rs
@@ -1,0 +1,49 @@
+// Copyright 2024 the Color Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Gradient example
+//!
+//! Outputs a test page to stdout.
+//!
+//! Typical usage:
+//!
+//! ```sh
+//! cargo run --example gradient 'oklab(0.5 0.2 0)' 'rgb(0, 200, 0, 0.8)' oklab
+//! ```
+
+use color::{gradient, ColorSpaceTag, CssColor, GradientIter, HueDirection, Srgb};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let c1_s = args.next().expect("give color as arg");
+    let c1 = color::parse_color(&c1_s).expect("error parsing color 1");
+    let c2_s = args.next().expect("give 2 colors as arg");
+    let c2 = color::parse_color(&c2_s).expect("error parsing color 2");
+    let cs_s_raw = args.next();
+    let cs_s = cs_s_raw.as_deref().unwrap_or("srgb");
+    let cs: ColorSpaceTag = cs_s.parse().expect("error parsing colorspace");
+    let gradient: GradientIter<Srgb> = gradient(c1, c2, cs, HueDirection::default(), 0.02);
+    println!("<!DOCTYPE html>");
+    println!("<html>");
+    println!("<head>");
+    println!("<style>");
+    println!("div.g {{ height: 100px }}");
+    println!("#basic {{ background: linear-gradient(to right in {cs_s}, {c1_s}, {c2_s}) }}");
+    print!("#ours {{ background: linear-gradient(to right");
+    for (t, stop) in gradient {
+        print!(
+            ", {} {}%",
+            CssColor::from_alpha_color(stop.un_premultiply()),
+            t * 100.0
+        );
+    }
+    println!(") }}");
+    println!("</style>");
+    println!("</head>");
+    println!("<body>");
+    println!("<div>{c1_s} {c2_s} {cs_s}</div>");
+    println!("<div class='g' id='basic'></div>");
+    println!("<div class='g' id='ours'></div>");
+    println!("</body>");
+    println!("</html>");
+}

--- a/color/examples/interp.rs
+++ b/color/examples/interp.rs
@@ -1,0 +1,57 @@
+// Copyright 2024 the Color Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Interpolation example
+//!
+//! Outputs a test page to stdout.
+//!
+//! Typical usage:
+//!
+//! ```sh
+//! cargo run --example interp 'oklab(0.5 0.2 0)' 'rgb(0, 200, 0, 0.8)' oklab
+//! ```
+
+use color::{ColorSpaceTag, HueDirection};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let c1_s = args.next().expect("give color as arg");
+    let c1 = color::parse_color(&c1_s).expect("error parsing color 1");
+    let c2_s = args.next().expect("give 2 colors as arg");
+    let c2 = color::parse_color(&c2_s).expect("error parsing color 2");
+    let cs_s_raw = args.next();
+    let cs_s = cs_s_raw.as_deref().unwrap_or("srgb");
+    let cs: ColorSpaceTag = cs_s.parse().expect("error parsing colorspace");
+    const N: usize = 20;
+    println!("<!DOCTYPE html>");
+    println!("<html>");
+    println!("<head>");
+    println!("<style>");
+    println!("div.g {{ height: 100px }}");
+    let pct = 100.0 / N as f64;
+    println!("span {{ width: {pct}%; display: inline-block; height: 100px; margin: 0 }}");
+    let interpolator = c1.interpolate(c2, cs, HueDirection::default());
+    for i in 0..=N {
+        let t = i as f32 / (N as f32);
+        let c = interpolator.eval(t);
+        if i == 0 || i == N {
+            println!("#s{i} {{ background: {c}; width: {}% }}", pct / 2.0);
+        } else {
+            println!("#s{i} {{ background: {c} }}");
+        }
+    }
+    println!("#basic {{ background: linear-gradient(to right in {cs_s}, {c1_s}, {c2_s}) }}");
+    println!("</style>");
+    println!("</head>");
+    println!("<body>");
+    println!("<div>{c1_s} {c2_s} {cs_s}</div>");
+    println!("<div class='g' id='basic'></div>");
+    println!("<div class='g'>");
+    for i in 0..=N {
+        print!("<span id='s{i}'></span>");
+    }
+    println!();
+    println!("</div>");
+    println!("</body>");
+    println!("</html>");
+}

--- a/color/examples/parse.rs
+++ b/color/examples/parse.rs
@@ -1,0 +1,28 @@
+// Copyright 2024 the Color Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Parsing example
+//!
+//! Outputs debug strings for the parse to stdout
+//!
+//! Typical usage:
+//!
+//! ```sh
+//! cargo run --example parse 'oklab(0.5 0.2 0)'
+//! ```
+
+use color::{AlphaColor, CssColor, Srgb};
+
+fn main() {
+    let arg = std::env::args().nth(1).expect("give color as arg");
+    match color::parse_color(&arg) {
+        Ok(color) => {
+            println!("display: {color}");
+            println!("debug: {color:?}");
+            let tagged = CssColor::to_tagged_color(color);
+            let srgba: AlphaColor<Srgb> = tagged.to_alpha_color();
+            println!("{srgba:?}");
+        }
+        Err(e) => println!("error: {e}"),
+    }
+}

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Color Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use core::f32;
+use core::{any::TypeId, f32};
 
 use crate::{matmul, tagged::ColorSpaceTag};
 
@@ -57,6 +57,16 @@ pub trait ColorSpace: Clone + Copy + 'static {
         let rgb = Self::to_linear_srgb(src);
         let scaled = LinearSrgb::scale_chroma(rgb, scale);
         Self::from_linear_srgb(scaled)
+    }
+
+    /// Convert to a different color space.
+    fn convert<TargetCS: ColorSpace>(src: [f32; 3]) -> [f32; 3] {
+        if TypeId::of::<Self>() == TypeId::of::<TargetCS>() {
+            src
+        } else {
+            let lin_rgb = Self::to_linear_srgb(src);
+            TargetCS::from_linear_srgb(lin_rgb)
+        }
     }
 }
 
@@ -256,6 +266,24 @@ impl ColorSpace for Oklab {
     }
 }
 
+/// Rectangular to cylindrical conversion.
+fn lab_to_lch([l, a, b]: [f32; 3]) -> [f32; 3] {
+    let mut h = b.atan2(a) * (180. / f32::consts::PI);
+    if h < 0.0 {
+        h += 360.0;
+    }
+    let c = b.hypot(a);
+    [l, c, h]
+}
+
+/// Cylindrical to rectangular conversion.
+fn lch_to_lab([l, c, h]: [f32; 3]) -> [f32; 3] {
+    let (sin, cos) = (h * (f32::consts::PI / 180.)).sin_cos();
+    let a = c * cos;
+    let b = c * sin;
+    [l, a, b]
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct Oklch;
 
@@ -265,22 +293,11 @@ impl ColorSpace for Oklch {
     const LAYOUT: ColorSpaceLayout = ColorSpaceLayout::HueThird;
 
     fn from_linear_srgb(src: [f32; 3]) -> [f32; 3] {
-        let lab = Oklab::from_linear_srgb(src);
-        let l = lab[0];
-        let mut h = lab[2].atan2(lab[1]) * (180. / f32::consts::PI);
-        if h < 0.0 {
-            h += 360.0;
-        }
-        let c = lab[2].hypot(lab[1]);
-        [l, c, h]
+        lab_to_lch(Oklab::from_linear_srgb(src))
     }
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
-        let l = src[0];
-        let (sin, cos) = (src[2] * (f32::consts::PI / 180.)).sin_cos();
-        let a = src[1] * cos;
-        let b = src[1] * sin;
-        Oklab::to_linear_srgb([l, a, b])
+        Oklab::to_linear_srgb(lch_to_lab(src))
     }
 
     fn scale_chroma(src: [f32; 3], scale: f32) -> [f32; 3] {

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -264,6 +264,17 @@ impl ColorSpace for Oklab {
     fn scale_chroma(src: [f32; 3], scale: f32) -> [f32; 3] {
         [src[0], src[1] * scale, src[2] * scale]
     }
+
+    fn convert<TargetCS: ColorSpace>(src: [f32; 3]) -> [f32; 3] {
+        if TypeId::of::<Self>() == TypeId::of::<TargetCS>() {
+            src
+        } else if TypeId::of::<TargetCS>() == TypeId::of::<Oklch>() {
+            lab_to_lch(src)
+        } else {
+            let lin_rgb = Self::to_linear_srgb(src);
+            TargetCS::from_linear_srgb(lin_rgb)
+        }
+    }
 }
 
 /// Rectangular to cylindrical conversion.
@@ -302,5 +313,16 @@ impl ColorSpace for Oklch {
 
     fn scale_chroma(src: [f32; 3], scale: f32) -> [f32; 3] {
         [src[0], src[1] * scale, src[2]]
+    }
+
+    fn convert<TargetCS: ColorSpace>(src: [f32; 3]) -> [f32; 3] {
+        if TypeId::of::<Self>() == TypeId::of::<TargetCS>() {
+            src
+        } else if TypeId::of::<TargetCS>() == TypeId::of::<Oklab>() {
+            lch_to_lab(src)
+        } else {
+            let lin_rgb = Self::to_linear_srgb(src);
+            TargetCS::from_linear_srgb(lin_rgb)
+        }
     }
 }

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -60,6 +60,13 @@ pub trait ColorSpace: Clone + Copy + 'static {
     }
 
     /// Convert to a different color space.
+    ///
+    /// The default implementation is a no-op if the color spaces
+    /// are the same, otherwise converts from the source to linear
+    /// sRGB, then from that to the target. Implementations are
+    /// encouraged to specialize further (using the [`TypeId`] of
+    /// the color spaces), effectively finding a shortest path in
+    /// the conversion graph.
     fn convert<TargetCS: ColorSpace>(src: [f32; 3]) -> [f32; 3] {
         if TypeId::of::<Self>() == TypeId::of::<TargetCS>() {
             src

--- a/color/src/css.rs
+++ b/color/src/css.rs
@@ -41,6 +41,7 @@ impl From<TaggedColor> for CssColor {
 }
 
 impl CssColor {
+    #[must_use]
     pub fn to_tagged_color(self) -> TaggedColor {
         TaggedColor {
             cs: self.cs,
@@ -48,6 +49,7 @@ impl CssColor {
         }
     }
 
+    #[must_use]
     pub fn to_alpha_color<CS: ColorSpace>(self) -> AlphaColor<CS> {
         self.to_tagged_color().to_alpha_color()
     }
@@ -58,6 +60,7 @@ impl CssColor {
     }
 
     #[must_use]
+    /// Convert to a different color space.
     pub fn convert(self, cs: ColorSpaceTag) -> Self {
         if self.cs == cs {
             // Note: §12 suggests that changing powerless to missing happens

--- a/color/src/tagged.rs
+++ b/color/src/tagged.rs
@@ -145,6 +145,15 @@ impl ColorSpaceTag {
         }
     }
 
+    pub fn convert(self, target: Self, src: [f32; 3]) -> [f32; 3] {
+        match (self, target) {
+            _ if self == target => src,
+            (Self::Oklab, Self::Oklch) | (Self::Lab, Self::Lch) => Oklab::convert::<Oklch>(src),
+            (Self::Oklch, Self::Oklab) | (Self::Lch, Self::Lab) => Oklch::convert::<Oklab>(src),
+            _ => target.from_linear_srgb(self.to_linear_srgb(src)),
+        }
+    }
+
     /// Scale the chroma by the given amount.
     ///
     /// See [`ColorSpace::scale_chroma`] for more details.
@@ -163,46 +172,29 @@ impl ColorSpaceTag {
 }
 
 impl TaggedColor {
-    pub fn from_linear_srgb(rgba: [f32; 4], cs: ColorSpaceTag) -> Self {
-        let (rgb, alpha) = split_alpha(rgba);
-        let opaque = cs.from_linear_srgb(rgb);
-        let components = add_alpha(opaque, alpha);
-        Self { cs, components }
-    }
-
+    #[must_use]
     pub fn from_alpha_color<CS: ColorSpace>(color: AlphaColor<CS>) -> Self {
         if let Some(cs) = CS::TAG {
-            Self {
-                cs,
-                components: color.components,
-            }
+            let components = color.components;
+            Self { cs, components }
         } else {
-            let components = color.convert::<LinearSrgb>().components;
-            Self {
-                cs: ColorSpaceTag::LinearSrgb,
-                components,
-            }
+            Self::from_alpha_color(color.convert::<LinearSrgb>())
         }
     }
 
+    #[must_use]
     pub fn to_alpha_color<CS: ColorSpace>(&self) -> AlphaColor<CS> {
-        if CS::TAG == Some(self.cs) {
-            AlphaColor::new(self.components)
+        if let Some(cs) = CS::TAG {
+            AlphaColor::new(self.convert(cs).components)
         } else {
-            let (opaque, alpha) = split_alpha(self.components);
-            let rgb = self.cs.to_linear_srgb(opaque);
-            let components = add_alpha(CS::from_linear_srgb(rgb), alpha);
-            AlphaColor::new(components)
+            self.to_alpha_color::<LinearSrgb>().convert()
         }
     }
 
     #[must_use]
     pub fn convert(self, cs: ColorSpaceTag) -> Self {
-        if self.cs == cs {
-            self
-        } else {
-            let linear = self.to_alpha_color::<LinearSrgb>();
-            Self::from_linear_srgb(linear.components, cs)
-        }
+        let (opaque, alpha) = split_alpha(self.components);
+        let components = add_alpha(self.cs.convert(cs, opaque), alpha);
+        Self { components, cs }
     }
 }

--- a/color/src/tagged.rs
+++ b/color/src/tagged.rs
@@ -121,6 +121,9 @@ impl ColorSpaceTag {
         }
     }
 
+    /// Convert an opaque color from linear sRGB.
+    ///
+    /// This is the tagged counterpart of [`ColorSpace::to_linear_srgb`].
     pub fn from_linear_srgb(self, rgb: [f32; 3]) -> [f32; 3] {
         match self {
             Self::Srgb => Srgb::from_linear_srgb(rgb),
@@ -133,6 +136,9 @@ impl ColorSpaceTag {
         }
     }
 
+    /// Convert an opaque color to linear sRGB.
+    ///
+    /// This is the tagged counterpart of [`ColorSpace::to_linear_srgb`].
     pub fn to_linear_srgb(self, src: [f32; 3]) -> [f32; 3] {
         match self {
             Self::Srgb => Srgb::to_linear_srgb(src),
@@ -145,6 +151,9 @@ impl ColorSpaceTag {
         }
     }
 
+    /// Convert the color components into the target color space.
+    ///
+    /// This is the tagged counterpart of [`ColorSpace::convert`].
     pub fn convert(self, target: Self, src: [f32; 3]) -> [f32; 3] {
         match (self, target) {
             _ if self == target => src,
@@ -156,7 +165,7 @@ impl ColorSpaceTag {
 
     /// Scale the chroma by the given amount.
     ///
-    /// See [`ColorSpace::scale_chroma`] for more details.
+    /// This is the tagged counterpart of [`ColorSpace::scale_chroma`].
     pub fn scale_chroma(self, src: [f32; 3], scale: f32) -> [f32; 3] {
         match self {
             Self::LinearSrgb => LinearSrgb::scale_chroma(src, scale),


### PR DESCRIPTION
Add a `convert` method to `ColorSpace`, and migrate logic in the individual color types to use that.

One consequence is that gradient interpolation in Oklch is expected to be faster, as the conversion to Oklab for error evaluation now doesn't go all the way back to linear sRGB.

Also adds examples from koloro crate, which were inadvertently omitted from the initial commit.

Removes `TaggedColor::from_linear_srgb` method, as that functionality can now be expressed more idiomatically with properly typed colors.