### PR TITLE
Hwb color space

### DIFF
--- a/color/examples/parse.rs
+++ b/color/examples/parse.rs
@@ -11,7 +11,7 @@
 //! cargo run --example parse 'oklab(0.5 0.2 0)'
 //! ```
 
-use color::{AlphaColor, Lab, Srgb};
+use color::{AlphaColor, Hwb, Lab, Srgb};
 
 fn main() {
     let arg = std::env::args().nth(1).expect("give color as arg");
@@ -23,6 +23,8 @@ fn main() {
             println!("{srgba:?}");
             let lab: AlphaColor<Lab> = color.to_alpha_color();
             println!("{lab:?}");
+            let hwb: AlphaColor<Hwb> = color.to_alpha_color();
+            println!("{hwb:?}");
         }
         Err(e) => println!("error: {e}"),
     }

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -226,6 +226,8 @@ impl ColorSpace for Srgb {
             src
         } else if TypeId::of::<TargetCS>() == TypeId::of::<Hsl>() {
             rgb_to_hsl(src)
+        } else if TypeId::of::<TargetCS>() == TypeId::of::<Hwb>() {
+            rgb_to_hwb(src)
         } else {
             let lin_rgb = Self::to_linear_srgb(src);
             TargetCS::from_linear_srgb(lin_rgb)
@@ -664,7 +666,7 @@ impl ColorSpace for Lch {
 /// - `S` - the saturation, where 0 is gray and 100 is maximally saturated.
 /// - `L` - the lightness, where 0 is black and 100 is white.
 ///
-/// This corresponds to the color space in [CSS Color Module Level 4 § 7 ][css-sec].
+/// This corresponds to the color space in [CSS Color Module Level 4 § 7][css-sec].
 ///
 /// [css-sec]: https://www.w3.org/TR/css-color-4/#the-hsl-notation
 #[derive(Clone, Copy, Debug)]
@@ -745,6 +747,8 @@ impl ColorSpace for Hsl {
             src
         } else if TypeId::of::<TargetCS>() == TypeId::of::<Srgb>() {
             hsl_to_rgb(src)
+        } else if TypeId::of::<TargetCS>() == TypeId::of::<Hwb>() {
+            rgb_to_hwb(hsl_to_rgb(src))
         } else {
             let lin_rgb = Self::to_linear_srgb(src);
             TargetCS::from_linear_srgb(lin_rgb)
@@ -753,5 +757,86 @@ impl ColorSpace for Hsl {
 
     fn clip([h, s, l]: [f32; 3]) -> [f32; 3] {
         [h, s.max(0.), l.clamp(0., 100.)]
+    }
+}
+
+/// 🌌 The HWB color space
+///
+/// The HWB color space is a convenient way to represent colors. It corresponds
+/// closely to popular color pickers, both a triangle with white, black, and
+/// fully saturated color at the corner, and also a rectangle with a hue spectrum
+/// at the top and black at the bottom, with whiteness as a separate slider. It
+/// was proposed in [HWB–A More Intuitive Hue-Based Color Model].
+///
+/// Its components are `[H, W, B]` with
+/// - `H` - the hue angle in degrees, with red at 0, green at 120, and blue at 240.
+/// - `W` - an amount of whiteness to mix in, with 100 being white.
+/// - `B` - an amount of blackness to mix in, with 100 being black.
+///
+/// The hue angle is the same as in [Hsl], and thus has the same flaw of poor hue
+/// uniformity.
+///
+/// This corresponds to the color space in [CSS Color Module Level 4 § 8][css-sec].
+///
+/// [css-sec]: https://www.w3.org/TR/css-color-4/#the-hwb-notation
+/// [HWB–A More Intuitive Hue-Based Color Model]: http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
+#[derive(Clone, Copy, Debug)]
+pub struct Hwb;
+
+/// Convert HWB to RGB.
+///
+/// Reference: § 8.1 of CSS Color 4 spec.
+fn hwb_to_rgb([h, w, b]: [f32; 3]) -> [f32; 3] {
+    let white = w * 0.01;
+    let black = b * 0.01;
+    if white + black >= 1.0 {
+        let gray = white / (white + black);
+        [gray, gray, gray]
+    } else {
+        let rgb = hsl_to_rgb([h, 100., 50.]);
+        rgb.map(|x| white + x * (1.0 - white - black))
+    }
+}
+
+/// Convert RGB to HWB.
+///
+/// Reference: § 8.2 of CSS Color 4 spec.
+fn rgb_to_hwb([r, g, b]: [f32; 3]) -> [f32; 3] {
+    let hsl = rgb_to_hsl([r, g, b]);
+    let white = r.min(g).min(b);
+    let black = 1.0 - r.max(g).max(b);
+    [hsl[0], white * 100., black * 100.]
+}
+
+impl ColorSpace for Hwb {
+    const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::Hwb);
+
+    const LAYOUT: ColorSpaceLayout = ColorSpaceLayout::HueFirst;
+
+    fn from_linear_srgb(src: [f32; 3]) -> [f32; 3] {
+        let rgb = Srgb::from_linear_srgb(src);
+        rgb_to_hwb(rgb)
+    }
+
+    fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
+        let rgb = hwb_to_rgb(src);
+        Srgb::to_linear_srgb(rgb)
+    }
+
+    fn convert<TargetCS: ColorSpace>(src: [f32; 3]) -> [f32; 3] {
+        if TypeId::of::<Self>() == TypeId::of::<TargetCS>() {
+            src
+        } else if TypeId::of::<TargetCS>() == TypeId::of::<Srgb>() {
+            hwb_to_rgb(src)
+        } else if TypeId::of::<TargetCS>() == TypeId::of::<Hsl>() {
+            rgb_to_hsl(hwb_to_rgb(src))
+        } else {
+            let lin_rgb = Self::to_linear_srgb(src);
+            TargetCS::from_linear_srgb(lin_rgb)
+        }
+    }
+
+    fn clip([h, w, b]: [f32; 3]) -> [f32; 3] {
+        [h, w.clamp(0., 100.), b.clamp(0., 100.)]
     }
 }

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -35,7 +35,8 @@ mod floatfuncs;
 
 pub use color::{AlphaColor, HueDirection, OpaqueColor, PremulColor};
 pub use colorspace::{
-    ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Lab, Lch, LinearSrgb, Oklab, Oklch, Srgb, XyzD65,
+    ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch, LinearSrgb, Oklab, Oklch, Srgb,
+    XyzD65,
 };
 pub use dynamic::{DynamicColor, Interpolator};
 pub use gradient::{gradient, GradientIter};

--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -407,6 +407,20 @@ impl<'a> Parser<'a> {
         Ok(color_from_components([h, s, l, alpha], ColorSpaceTag::Hsl))
     }
 
+    fn hwb(&mut self) -> Result<DynamicColor, ParseError> {
+        if !self.raw_ch(b'(') {
+            return Err(ParseError::ExpectedArguments);
+        }
+        let h = self.angle()?;
+        let w = self.scaled_component(1., 1.)?;
+        let b = self.scaled_component(1., 1.)?;
+        let alpha = self.optional_alpha()?;
+        if !self.ch(b')') {
+            return Err(ParseError::ExpectedClosingParenthesis);
+        }
+        Ok(color_from_components([h, w, b, alpha], ColorSpaceTag::Hwb))
+    }
+
     fn color(&mut self) -> Result<DynamicColor, ParseError> {
         if !self.raw_ch(b'(') {
             return Err(ParseError::ExpectedArguments);
@@ -455,6 +469,7 @@ pub fn parse_color(s: &str) -> Result<DynamicColor, ParseError> {
             "oklab" => parser.lab(1.0, 0.004, ColorSpaceTag::Oklab),
             "oklch" => parser.lch(1.0, 0.004, ColorSpaceTag::Oklch),
             "hsl" | "hsla" => parser.hsl(),
+            "hwb" => parser.hwb(),
             "color" => parser.color(),
             _ => {
                 if let Some([r, g, b, a]) = crate::x11_colors::lookup_palette(id) {

--- a/color/src/serialize.rs
+++ b/color/src/serialize.rs
@@ -84,12 +84,12 @@ impl core::fmt::Display for DynamicColor {
             ColorSpaceTag::LinearSrgb => write_color_function(self, "srgb-linear", f),
             ColorSpaceTag::DisplayP3 => write_color_function(self, "display-p3", f),
             ColorSpaceTag::Hsl => write_legacy_function(self, "hsl", 1.0, f),
+            ColorSpaceTag::Hwb => write_modern_function(self, "hwb", f),
             ColorSpaceTag::XyzD65 => write_color_function(self, "xyz", f),
             ColorSpaceTag::Lab => write_modern_function(self, "lab", f),
             ColorSpaceTag::Lch => write_modern_function(self, "lch", f),
             ColorSpaceTag::Oklab => write_modern_function(self, "oklab", f),
             ColorSpaceTag::Oklch => write_modern_function(self, "oklch", f),
-            _ => todo!(),
         }
     }
 }

--- a/color/src/tag.rs
+++ b/color/src/tag.rs
@@ -4,7 +4,7 @@
 //! The color space tag enum.
 
 use crate::{
-    ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Lab, Lch, LinearSrgb, Missing, Oklab, Oklch,
+    ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch, LinearSrgb, Missing, Oklab, Oklch,
     Srgb, XyzD65,
 };
 
@@ -137,7 +137,7 @@ impl ColorSpaceTag {
             Self::DisplayP3 => DisplayP3::from_linear_srgb(rgb),
             Self::XyzD65 => XyzD65::from_linear_srgb(rgb),
             Self::Hsl => Hsl::from_linear_srgb(rgb),
-            _ => todo!(),
+            Self::Hwb => Hwb::from_linear_srgb(rgb),
         }
     }
 
@@ -155,7 +155,7 @@ impl ColorSpaceTag {
             Self::DisplayP3 => DisplayP3::to_linear_srgb(src),
             Self::XyzD65 => XyzD65::to_linear_srgb(src),
             Self::Hsl => Hsl::to_linear_srgb(src),
-            _ => todo!(),
+            Self::Hwb => Hwb::to_linear_srgb(src),
         }
     }
 
@@ -169,6 +169,10 @@ impl ColorSpaceTag {
             (Self::Oklch, Self::Oklab) | (Self::Lch, Self::Lab) => Oklch::convert::<Oklab>(src),
             (Self::Srgb, Self::Hsl) => Srgb::convert::<Hsl>(src),
             (Self::Hsl, Self::Srgb) => Hsl::convert::<Srgb>(src),
+            (Self::Srgb, Self::Hwb) => Srgb::convert::<Hwb>(src),
+            (Self::Hwb, Self::Srgb) => Hwb::convert::<Srgb>(src),
+            (Self::Hsl, Self::Hwb) => Hsl::convert::<Hwb>(src),
+            (Self::Hwb, Self::Hsl) => Hwb::convert::<Hsl>(src),
             _ => target.from_linear_srgb(self.to_linear_srgb(src)),
         }
     }
@@ -203,7 +207,7 @@ impl ColorSpaceTag {
             Self::DisplayP3 => DisplayP3::clip(src),
             Self::XyzD65 => XyzD65::clip(src),
             Self::Hsl => Hsl::clip(src),
-            _ => todo!(),
+            Self::Hwb => Hwb::clip(src),
         }
     }
 }


### PR DESCRIPTION
Add HWB color space, basically following the spec. It's been spot-tested with non-HDR colors.

Serialization is to syntax which can be parsed by CSS Color 4, but doesn't include `%` for W and B, as is done by color.js. It also doesn't strictly follow serialization by the spec, which calls for the color to be lowered to RGB. To me this is an argument in favor of having a separate code path for strict CSS serialization.

In theory, HWB should be able to handle HDR colors with negative values for W and B. In practice, that's a bad idea, and in any case the current code does not roundtrip these correctly. That might be a flaw in the spec, and deserves deeper investigation.

Closes #19