### PR TITLE
Add Adobe RGB (1998) color space

### DIFF
--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -283,6 +283,79 @@ impl ColorSpace for DisplayP3 {
     }
 }
 
+/// 🌌 The Adobe RGB (1998) color space.
+///
+/// Adobe RGB is similar to [sRGB](`Srgb`) but has higher green chromaticity, thereby extending its
+/// gamut over sRGB on that component. It was developed to encompass typical color print gamuts.
+///
+/// Its components are `[r, g, b]` (red, green, and blue channels respectively), with `[0, 0, 0]`
+/// pure black and `[1, 1, 1]` white. The natural bounds of the channels are `[0, 1]`.
+///
+/// This corresponds to the color space in [CSS Color Module Level 4 § 10.5][css-sec] and is
+/// [characterized by the ICC][icc]. Adobe RGB is described [here][adobe] by Adobe.
+///
+/// [css-sec]: https://www.w3.org/TR/css-color-4/#predefined-a98-rgb
+/// [icc]: https://www.color.org/chardata/rgb/adobergb.xalter
+/// [adobe]: https://www.adobe.com/digitalimag/adobergb.html
+#[derive(Clone, Copy, Debug)]
+pub struct A98Rgb;
+
+impl ColorSpace for A98Rgb {
+    const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::A98Rgb);
+
+    fn to_linear_srgb([r, g, b]: [f32; 3]) -> [f32; 3] {
+        // XYZ_to_lin_sRGB * lin_A98_to_XYZ
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "exact rational, truncate at compile-time"
+        )]
+        const LINEAR_A98RGB_TO_SRGB: [[f32; 3]; 3] = [
+            [
+                (66_942_405. / 47_872_228.) as f32,
+                (-19_070_177. / 47_872_228.) as f32,
+                0.,
+            ],
+            [0., 1., 0.],
+            [
+                0.,
+                (-11_512_411. / 268_173_353.) as f32,
+                (279_685_764. / 268_173_353.) as f32,
+            ],
+        ];
+        matmul(
+            &LINEAR_A98RGB_TO_SRGB,
+            [r, g, b].map(|x| x.abs().powf(2.199_218_8).copysign(x)),
+        )
+    }
+
+    fn from_linear_srgb([r, g, b]: [f32; 3]) -> [f32; 3] {
+        // XYZ_to_lin_A98RGB * lin_sRGB_to_XYZ
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "exact rational, truncate at compile-time"
+        )]
+        const LINEAR_SRGB_TO_A98RGB: [[f32; 3]; 3] = [
+            [
+                (47_872_228. / 66_942_405.) as f32,
+                (19_070_177. / 66_942_405.) as f32,
+                0.0,
+            ],
+            [0., 1., 0.],
+            [
+                0.,
+                (11_512_411. / 279_685_764.) as f32,
+                (268_173_353. / 279_685_764.) as f32,
+            ],
+        ];
+        matmul(&LINEAR_SRGB_TO_A98RGB, [r, g, b])
+            .map(|x| x.abs().powf(1. / 2.199_218_8).copysign(x))
+    }
+
+    fn clip([r, g, b]: [f32; 3]) -> [f32; 3] {
+        [r.clamp(0., 1.), g.clamp(0., 1.), b.clamp(0., 1.)]
+    }
+}
+
 /// 🌌 The CIE XYZ color space with a 2° observer and a reference white of D65.
 ///
 /// Its components are `[X, Y, Z]`. The components are unbounded, but are usually positive.
@@ -841,5 +914,25 @@ impl ColorSpace for Hwb {
 
     fn clip([h, w, b]: [f32; 3]) -> [f32; 3] {
         [h, w.clamp(0., 100.), b.clamp(0., 100.)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{A98Rgb, ColorSpace, OpaqueColor, Srgb};
+
+    fn almost_equal<CS: ColorSpace>(col1: [f32; 3], col2: [f32; 3]) -> bool {
+        OpaqueColor::<CS>::new(col1).difference(OpaqueColor::new(col2)) < 0.001
+    }
+
+    #[test]
+    fn a98rgb_srgb() {
+        for (srgb, a98) in [
+            ([0.1, 0.2, 0.3], [0.15511, 0.21232, 0.30150]),
+            ([0., 1., 0.], [0.56493, 1., 0.23445]),
+        ] {
+            assert!(almost_equal::<Srgb>(srgb, A98Rgb::convert::<Srgb>(a98)));
+            assert!(almost_equal::<A98Rgb>(a98, Srgb::convert::<A98Rgb>(srgb)));
+        }
     }
 }

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -921,14 +921,14 @@ mod tests {
     use crate::{A98Rgb, ColorSpace, OpaqueColor, Srgb};
 
     fn almost_equal<CS: ColorSpace>(col1: [f32; 3], col2: [f32; 3]) -> bool {
-        OpaqueColor::<CS>::new(col1).difference(OpaqueColor::new(col2)) < 0.001
+        OpaqueColor::<CS>::new(col1).difference(OpaqueColor::new(col2)) < 1e-4
     }
 
     #[test]
     fn a98rgb_srgb() {
         for (srgb, a98) in [
-            ([0.1, 0.2, 0.3], [0.15511, 0.21232, 0.30150]),
-            ([0., 1., 0.], [0.56493, 1., 0.23445]),
+            ([0.1, 0.2, 0.3], [0.155_114, 0.212_317, 0.301_498]),
+            ([0., 1., 0.], [0.564_972, 1., 0.234_424]),
         ] {
             assert!(almost_equal::<Srgb>(srgb, A98Rgb::convert::<Srgb>(a98)));
             assert!(almost_equal::<A98Rgb>(a98, Srgb::convert::<A98Rgb>(srgb)));

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -324,7 +324,7 @@ impl ColorSpace for A98Rgb {
         ];
         matmul(
             &LINEAR_A98RGB_TO_SRGB,
-            [r, g, b].map(|x| x.abs().powf(2.199_218_8).copysign(x)),
+            [r, g, b].map(|x| x.abs().powf(563. / 256.).copysign(x)),
         )
     }
 
@@ -347,8 +347,7 @@ impl ColorSpace for A98Rgb {
                 (268_173_353. / 279_685_764.) as f32,
             ],
         ];
-        matmul(&LINEAR_SRGB_TO_A98RGB, [r, g, b])
-            .map(|x| x.abs().powf(1. / 2.199_218_8).copysign(x))
+        matmul(&LINEAR_SRGB_TO_A98RGB, [r, g, b]).map(|x| x.abs().powf(256. / 563.).copysign(x))
     }
 
     fn clip([r, g, b]: [f32; 3]) -> [f32; 3] {

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -35,8 +35,8 @@ mod floatfuncs;
 
 pub use color::{AlphaColor, HueDirection, OpaqueColor, PremulColor};
 pub use colorspace::{
-    ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch, LinearSrgb, Oklab, Oklch, Srgb,
-    XyzD65,
+    A98Rgb, ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch, LinearSrgb, Oklab, Oklch,
+    Srgb, XyzD65,
 };
 pub use dynamic::{DynamicColor, Interpolator};
 pub use gradient::{gradient, GradientIter};

--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -433,6 +433,7 @@ impl<'a> Parser<'a> {
             "srgb" => ColorSpaceTag::Srgb,
             "srgb-linear" => ColorSpaceTag::LinearSrgb,
             "display-p3" => ColorSpaceTag::DisplayP3,
+            "a98-rgb" => ColorSpaceTag::A98Rgb,
             "xyz" | "xyz-d65" => ColorSpaceTag::XyzD65,
             _ => return Err(ParseError::UnknownColorSpace),
         };
@@ -536,6 +537,7 @@ impl FromStr for ColorSpaceTag {
             "oklab" => Ok(Self::Oklab),
             "oklch" => Ok(Self::Oklch),
             "display-p3" => Ok(Self::DisplayP3),
+            "a98-rgb" => Ok(Self::A98Rgb),
             "xyz" | "xyz-d65" => Ok(Self::XyzD65),
             _ => Err(ParseError::UnknownColorSpace),
         }

--- a/color/src/serialize.rs
+++ b/color/src/serialize.rs
@@ -83,6 +83,7 @@ impl core::fmt::Display for DynamicColor {
             ColorSpaceTag::Srgb => write_legacy_function(self, "rgb", 255.0, f),
             ColorSpaceTag::LinearSrgb => write_color_function(self, "srgb-linear", f),
             ColorSpaceTag::DisplayP3 => write_color_function(self, "display-p3", f),
+            ColorSpaceTag::A98Rgb => write_color_function(self, "a98-rgb", f),
             ColorSpaceTag::Hsl => write_legacy_function(self, "hsl", 1.0, f),
             ColorSpaceTag::Hwb => write_modern_function(self, "hwb", f),
             ColorSpaceTag::XyzD65 => write_color_function(self, "xyz", f),

--- a/color/src/tag.rs
+++ b/color/src/tag.rs
@@ -4,8 +4,8 @@
 //! The color space tag enum.
 
 use crate::{
-    ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch, LinearSrgb, Missing, Oklab, Oklch,
-    Srgb, XyzD65,
+    A98Rgb, ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch, LinearSrgb, Missing,
+    Oklab, Oklch, Srgb, XyzD65,
 };
 
 /// The color space tag for dynamic colors.
@@ -39,6 +39,8 @@ pub enum ColorSpaceTag {
     Oklch,
     /// The [`DisplayP3`] color space.
     DisplayP3,
+    /// The [`A98Rgb`] color space.
+    A98Rgb,
     /// The [`XyzD65`] color space.
     XyzD65,
 }
@@ -60,8 +62,8 @@ impl ColorSpaceTag {
         matches!(
             (self, other),
             (
-                Srgb | LinearSrgb | DisplayP3 | XyzD65,
-                Srgb | LinearSrgb | DisplayP3 | XyzD65
+                Srgb | LinearSrgb | DisplayP3 | A98Rgb | XyzD65,
+                Srgb | LinearSrgb | DisplayP3 | A98Rgb | XyzD65
             ) | (Lab | Oklab, Lab | Oklab)
                 | (Lch | Oklch, Lch | Oklch)
         )
@@ -135,6 +137,7 @@ impl ColorSpaceTag {
             Self::Oklab => Oklab::from_linear_srgb(rgb),
             Self::Oklch => Oklch::from_linear_srgb(rgb),
             Self::DisplayP3 => DisplayP3::from_linear_srgb(rgb),
+            Self::A98Rgb => A98Rgb::from_linear_srgb(rgb),
             Self::XyzD65 => XyzD65::from_linear_srgb(rgb),
             Self::Hsl => Hsl::from_linear_srgb(rgb),
             Self::Hwb => Hwb::from_linear_srgb(rgb),
@@ -153,6 +156,7 @@ impl ColorSpaceTag {
             Self::Oklab => Oklab::to_linear_srgb(src),
             Self::Oklch => Oklch::to_linear_srgb(src),
             Self::DisplayP3 => DisplayP3::to_linear_srgb(src),
+            Self::A98Rgb => A98Rgb::to_linear_srgb(src),
             Self::XyzD65 => XyzD65::to_linear_srgb(src),
             Self::Hsl => Hsl::to_linear_srgb(src),
             Self::Hwb => Hwb::to_linear_srgb(src),
@@ -205,6 +209,7 @@ impl ColorSpaceTag {
             Self::Oklab => Oklab::clip(src),
             Self::Oklch => Oklch::clip(src),
             Self::DisplayP3 => DisplayP3::clip(src),
+            Self::A98Rgb => A98Rgb::clip(src),
             Self::XyzD65 => XyzD65::clip(src),
             Self::Hsl => Hsl::clip(src),
             Self::Hwb => Hwb::clip(src),


### PR DESCRIPTION
The Linear A98 RGB <-> Linear sRGB matrices are based on the exact rational conversion matrices calculated from the XYZ chromaticities. This crate doesn't need the exact rationals as they're truncated to f32 at compile-time anyway, but it might be worth having to serve as a reference for other people. It would be nice to have agreement across implementations at any given precision.

The same _can_ be done for other basis change matrices, though it becomes somewhat unwieldy as the number of steps combined into the matrix increases; by my calculation element (0,0) of the Linear sRGB to XYZ-D50 matrix with linear Bradford adaptation is exactly `7206783369626736730083375524119595656 / 16526827482518743502029642682152162875`.

This is all based on the assumption that the color spaces' specified xy chromaticities are normative, and the specified matrices in the specs are computed off those.