### PR TITLE
Add XYZ-D50 color space

### DIFF
--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -355,6 +355,49 @@ impl ColorSpace for A98Rgb {
     }
 }
 
+/// 🌌 The CIE XYZ color space with a 2° observer and a reference white of D50.
+///
+/// Its components are `[X, Y, Z]`. The components are unbounded, but are usually positive.
+/// Reference white has a luminance `Y` of 1.
+///
+/// This corresponds to the color space in [CSS Color Module Level 4 § 10.8][css-sec]. It is
+/// defined in CIE 015:2018.
+///
+/// See the [XYZ-D65 color space](`XyzD65`) documentation for some background information on color
+/// spaces.
+#[derive(Clone, Copy, Debug)]
+pub struct XyzD50;
+
+impl ColorSpace for XyzD50 {
+    const IS_LINEAR: bool = true;
+
+    const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::XyzD50);
+
+    fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
+        // XYZ_to_lin_sRGB * D50_to_D65
+        const XYZ_TO_LINEAR_SRGB: [[f32; 3]; 3] = [
+            [3.134_136, -1.617_386, -0.490_662_22],
+            [-0.978_795_47, 1.916_254_4, 0.033_442_874],
+            [0.071_955_39, -0.228_976_76, 1.405_386_1],
+        ];
+        matmul(&XYZ_TO_LINEAR_SRGB, src)
+    }
+
+    fn from_linear_srgb(src: [f32; 3]) -> [f32; 3] {
+        // D65_to_D50 * lin_sRGB_to_XYZ
+        const LINEAR_SRGB_TO_XYZ: [[f32; 3]; 3] = [
+            [0.436_065_73, 0.385_151_5, 0.143_078_42],
+            [0.222_493_17, 0.716_887, 0.060_619_81],
+            [0.013_923_922, 0.097_081_326, 0.714_099_35],
+        ];
+        matmul(&LINEAR_SRGB_TO_XYZ, src)
+    }
+
+    fn clip([x, y, z]: [f32; 3]) -> [f32; 3] {
+        [x, y, z]
+    }
+}
+
 /// 🌌 The CIE XYZ color space with a 2° observer and a reference white of D65.
 ///
 /// Its components are `[X, Y, Z]`. The components are unbounded, but are usually positive.

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -409,7 +409,9 @@ impl ColorSpace for XyzD50 {
 /// Reference white has a luminance `Y` of 1.
 ///
 /// This corresponds to the color space in [CSS Color Module Level 4 § 10.8][css-sec]. It is
-/// defined in CIE 015:2018.
+/// defined in CIE 015:2018. Following [CSS Color Module Level 4 § 11][css-chromatic-adaptation],
+/// the conversion between D50 and D65 white points is done with the standard Bradford linear
+/// chromatic adaptation transform.
 ///
 /// # Human color vision and color spaces
 ///
@@ -449,6 +451,7 @@ impl ColorSpace for XyzD50 {
 /// a good introduction to color theory as relevant to color spaces.
 ///
 /// [css-sec]: https://www.w3.org/TR/css-color-4/#predefined-xyz
+/// [css-chromatic-adaptation]: https://www.w3.org/TR/css-color-4/#color-conversion
 /// [wikipedia-cie]: https://en.wikipedia.org/wiki/CIE_1931_color_space
 #[derive(Clone, Copy, Debug)]
 pub struct XyzD65;

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -365,6 +365,8 @@ impl ColorSpace for A98Rgb {
 ///
 /// See the [XYZ-D65 color space](`XyzD65`) documentation for some background information on color
 /// spaces.
+///
+/// [css-sec]: https://www.w3.org/TR/css-color-4/#predefined-xyz
 #[derive(Clone, Copy, Debug)]
 pub struct XyzD50;
 

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -361,12 +361,15 @@ impl ColorSpace for A98Rgb {
 /// Reference white has a luminance `Y` of 1.
 ///
 /// This corresponds to the color space in [CSS Color Module Level 4 § 10.8][css-sec]. It is
-/// defined in CIE 015:2018.
+/// defined in CIE 015:2018. Following [CSS Color Module Level 4 § 11][css-chromatic-adaptation],
+/// the conversion between D50 and D65 white points is done with the standard Bradford linear
+/// chromatic adaptation transform.
 ///
 /// See the [XYZ-D65 color space](`XyzD65`) documentation for some background information on color
 /// spaces.
 ///
 /// [css-sec]: https://www.w3.org/TR/css-color-4/#predefined-xyz
+/// [css-chromatic-adaptation]: https://www.w3.org/TR/css-color-4/#color-conversion
 #[derive(Clone, Copy, Debug)]
 pub struct XyzD50;
 

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -46,7 +46,7 @@ mod floatfuncs;
 pub use color::{AlphaColor, HueDirection, OpaqueColor, PremulColor};
 pub use colorspace::{
     A98Rgb, ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch, LinearSrgb, Oklab, Oklch,
-    Srgb, XyzD65,
+    Srgb, XyzD50, XyzD65,
 };
 pub use dynamic::{DynamicColor, Interpolator};
 pub use gradient::{gradient, GradientIter};

--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -434,6 +434,7 @@ impl<'a> Parser<'a> {
             "srgb-linear" => ColorSpaceTag::LinearSrgb,
             "display-p3" => ColorSpaceTag::DisplayP3,
             "a98-rgb" => ColorSpaceTag::A98Rgb,
+            "xyz-d50" => ColorSpaceTag::XyzD50,
             "xyz" | "xyz-d65" => ColorSpaceTag::XyzD65,
             _ => return Err(ParseError::UnknownColorSpace),
         };
@@ -538,6 +539,7 @@ impl FromStr for ColorSpaceTag {
             "oklch" => Ok(Self::Oklch),
             "display-p3" => Ok(Self::DisplayP3),
             "a98-rgb" => Ok(Self::A98Rgb),
+            "xyz-d50" => Ok(Self::XyzD50),
             "xyz" | "xyz-d65" => Ok(Self::XyzD65),
             _ => Err(ParseError::UnknownColorSpace),
         }

--- a/color/src/serialize.rs
+++ b/color/src/serialize.rs
@@ -86,6 +86,7 @@ impl core::fmt::Display for DynamicColor {
             ColorSpaceTag::A98Rgb => write_color_function(self, "a98-rgb", f),
             ColorSpaceTag::Hsl => write_legacy_function(self, "hsl", 1.0, f),
             ColorSpaceTag::Hwb => write_modern_function(self, "hwb", f),
+            ColorSpaceTag::XyzD50 => write_color_function(self, "xyz-d50", f),
             ColorSpaceTag::XyzD65 => write_color_function(self, "xyz", f),
             ColorSpaceTag::Lab => write_modern_function(self, "lab", f),
             ColorSpaceTag::Lch => write_modern_function(self, "lch", f),

--- a/color/src/tag.rs
+++ b/color/src/tag.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     A98Rgb, ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch, LinearSrgb, Missing,
-    Oklab, Oklch, Srgb, XyzD65,
+    Oklab, Oklch, Srgb, XyzD50, XyzD65,
 };
 
 /// The color space tag for dynamic colors.
@@ -41,6 +41,8 @@ pub enum ColorSpaceTag {
     DisplayP3,
     /// The [`A98Rgb`] color space.
     A98Rgb,
+    /// The [`XyzD50`] color space.
+    XyzD50,
     /// The [`XyzD65`] color space.
     XyzD65,
 }
@@ -62,8 +64,8 @@ impl ColorSpaceTag {
         matches!(
             (self, other),
             (
-                Srgb | LinearSrgb | DisplayP3 | A98Rgb | XyzD65,
-                Srgb | LinearSrgb | DisplayP3 | A98Rgb | XyzD65
+                Srgb | LinearSrgb | DisplayP3 | A98Rgb | XyzD50 | XyzD65,
+                Srgb | LinearSrgb | DisplayP3 | A98Rgb | XyzD50 | XyzD65
             ) | (Lab | Oklab, Lab | Oklab)
                 | (Lch | Oklch, Lch | Oklch)
         )
@@ -138,6 +140,7 @@ impl ColorSpaceTag {
             Self::Oklch => Oklch::from_linear_srgb(rgb),
             Self::DisplayP3 => DisplayP3::from_linear_srgb(rgb),
             Self::A98Rgb => A98Rgb::from_linear_srgb(rgb),
+            Self::XyzD50 => XyzD50::from_linear_srgb(rgb),
             Self::XyzD65 => XyzD65::from_linear_srgb(rgb),
             Self::Hsl => Hsl::from_linear_srgb(rgb),
             Self::Hwb => Hwb::from_linear_srgb(rgb),
@@ -157,6 +160,7 @@ impl ColorSpaceTag {
             Self::Oklch => Oklch::to_linear_srgb(src),
             Self::DisplayP3 => DisplayP3::to_linear_srgb(src),
             Self::A98Rgb => A98Rgb::to_linear_srgb(src),
+            Self::XyzD50 => XyzD50::to_linear_srgb(src),
             Self::XyzD65 => XyzD65::to_linear_srgb(src),
             Self::Hsl => Hsl::to_linear_srgb(src),
             Self::Hwb => Hwb::to_linear_srgb(src),
@@ -210,6 +214,7 @@ impl ColorSpaceTag {
             Self::Oklch => Oklch::clip(src),
             Self::DisplayP3 => DisplayP3::clip(src),
             Self::A98Rgb => A98Rgb::clip(src),
+            Self::XyzD50 => XyzD50::clip(src),
             Self::XyzD65 => XyzD65::clip(src),
             Self::Hsl => Hsl::clip(src),
             Self::Hwb => Hwb::clip(src),


### PR DESCRIPTION
For completeness, as in https://github.com/linebender/color/pull/35 and taking the Bradford matrix in Equation E.1 of https://www.color.org/specification/ICC.1-2022-05.pdf at the given (truncated?) accuracy as normative, the exact matrices would be:

To linear srgb

```
[  19465502010224276276661593551020496311 / 6210803527298350782937583386584271072      -10045266661493418335616520203717568647 / 6210803527298350782937583386584271072       -380925829214284601014311508394428683 / 776350440912293847867197923323033884]
[-337356623761478054942371793176577217279 / 344665082585568555920268859305640519120    660465973240145571160426551266636201223 / 344665082585568555920268859305640519120     2881647679747383054412944838679675439 / 86166270646392138980067214826410129780]
[   2503474197576354408723248131063361565 / 34792030292382166980624902741050598072      -7966566363741328722516709107949426845 / 34792030292382166980624902741050598072     12224058376536618906761866944690588945 / 8698007573095541745156225685262649518]
```

From linear srgb

```
[   7206783369626736730083375524119595656 / 16526827482518743502029642682152162875     3819199532176938646079263481703233594 / 9916096489511246101217785609291297725     7093897089705637404890354974940967287 / 49580482447556230506088928046456488625]
[ 25739744479006591112764525210798971992 / 115687792377631204514207498775065140125    49761045557456802603970459172387624758 / 69412675426578722708524499265039084075    3005559415512832454925232118694340087 / 49580482447556230506088928046456488625]
[  4832483205940751745766711439175373976 / 347063377132893613542622496325195420375    20216023346571976395880647682496608024 / 208238026279736168125573497795117252225 106216171879262899567856164222064208586 / 148741447342668691518266784139369465875]
```