### PR TITLE
Implementation of Rgba8 type

### DIFF
--- a/color/src/floatfuncs.rs
+++ b/color/src/floatfuncs.rs
@@ -44,6 +44,7 @@ define_float_funcs! {
     fn hypot(self, other: Self) -> Self => hypotf;
     // Note: powi is missing because its libm implementation is not efficient
     fn powf(self, n: Self) -> Self => powf;
+    fn round(self) -> Self => roundf;
     fn sin_cos(self) -> (Self, Self) => sincosf;
     fn sqrt(self) -> Self => sqrtf;
 }

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -36,6 +36,7 @@ mod missing;
 // Note: this may become feature-gated; we'll decide this soon
 mod dynamic;
 mod parse;
+mod rgba8;
 mod serialize;
 mod tag;
 mod x11_colors;
@@ -52,6 +53,7 @@ pub use dynamic::{DynamicColor, Interpolator};
 pub use gradient::{gradient, GradientIter};
 pub use missing::Missing;
 pub use parse::{parse_color, ParseError};
+pub use rgba8::Rgba8;
 pub use tag::ColorSpaceTag;
 
 const fn u8_to_f32(x: u32) -> f32 {
@@ -68,6 +70,8 @@ fn matmul(m: &[[f32; 3]; 3], x: [f32; 3]) -> [f32; 3] {
 
 impl AlphaColor<Srgb> {
     /// Create a color from 8-bit rgba values.
+    ///
+    /// Note: for conversion from the [`Rgba8`] type, just use the `From` trait.
     pub const fn from_rgba8(r: u8, g: u8, b: u8, a: u8) -> Self {
         let components = [
             u8_to_f32(r as u32),

--- a/color/src/rgba8.rs
+++ b/color/src/rgba8.rs
@@ -1,0 +1,29 @@
+// Copyright 2024 the Color Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{AlphaColor, Srgb};
+
+/// A packed representation of sRGB colors.
+///
+/// Encoding sRGB with 8 bits per component is extremely common, as
+/// it is efficient and convenient, even if limited in accuracy and
+/// gamut.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Rgba8 {
+    /// Red component.
+    pub r: u8,
+    /// Green component.
+    pub g: u8,
+    /// Blue component.
+    pub b: u8,
+    /// Alpha component.
+    ///
+    /// Alpha is interpreted as separated alpha.
+    pub a: u8,
+}
+
+impl From<Rgba8> for AlphaColor<Srgb> {
+    fn from(value: Rgba8) -> Self {
+        Self::from_rgba8(value.r, value.g, value.b, value.a)
+    }
+}

--- a/color/src/serialize.rs
+++ b/color/src/serialize.rs
@@ -5,7 +5,7 @@
 
 use core::fmt::{Formatter, Result};
 
-use crate::{ColorSpaceTag, DynamicColor};
+use crate::{ColorSpaceTag, DynamicColor, Rgba8};
 
 fn write_scaled_component(
     color: &DynamicColor,
@@ -80,7 +80,7 @@ impl core::fmt::Display for DynamicColor {
         match self.cs {
             // A case can be made this isn't the best serialization in general,
             // because CSS parsing of out-of-gamut components will clamp.
-            ColorSpaceTag::Srgb => write_legacy_function(self, "rgb", 255.0, f),
+            ColorSpaceTag::Srgb => write_color_function(self, "srgb", f),
             ColorSpaceTag::LinearSrgb => write_color_function(self, "srgb-linear", f),
             ColorSpaceTag::DisplayP3 => write_color_function(self, "display-p3", f),
             ColorSpaceTag::A98Rgb => write_color_function(self, "a98-rgb", f),
@@ -92,6 +92,45 @@ impl core::fmt::Display for DynamicColor {
             ColorSpaceTag::Lch => write_modern_function(self, "lch", f),
             ColorSpaceTag::Oklab => write_modern_function(self, "oklab", f),
             ColorSpaceTag::Oklch => write_modern_function(self, "oklch", f),
+        }
+    }
+}
+
+impl core::fmt::Display for Rgba8 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        if self.a == 255 {
+            write!(f, "rgb({}, {}, {})", self.r, self.g, self.b)
+        } else {
+            let a = self.a as f32 * (1.0 / 255.0);
+            write!(f, "rgba({}, {}, {}, {a})", self.r, self.g, self.b)
+        }
+    }
+}
+
+impl core::fmt::LowerHex for Rgba8 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        if self.a == 255 {
+            write!(f, "#{:02x}{:02x}{:02x})", self.r, self.g, self.b)
+        } else {
+            write!(
+                f,
+                "#{:02x}{:02x}{:02x}{:02x})",
+                self.r, self.g, self.b, self.a
+            )
+        }
+    }
+}
+
+impl core::fmt::UpperHex for Rgba8 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        if self.a == 255 {
+            write!(f, "#{:02X}{:02X}{:02X})", self.r, self.g, self.b)
+        } else {
+            write!(
+                f,
+                "#{:02X}{:02X}{:02X}{:02X})",
+                self.r, self.g, self.b, self.a
+            )
         }
     }
 }


### PR DESCRIPTION
Adds Rgba8 type and some conversions and formatting.

This PR also changes the serialization of srgb to use the color function. If legacy RGB serialization is desired, the client can convert to Rgba8 first.

Closes #24.