### PR TITLE
Improve interop with `bytemuck` and FFI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,16 @@
 version = 3
 
 [[package]]
+name = "bytemuck"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+
+[[package]]
 name = "color"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "libm",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/color"
 
 [workspace.lints]
-rust.unsafe_code = "forbid"
+rust.unsafe_code = "deny"
 
 # LINEBENDER LINT SET - v1
 # See https://linebender.org/wiki/canonical-lints/

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -22,8 +22,14 @@ targets = []
 default = ["std"]
 std = []
 libm = ["dep:libm"]
+bytemuck = ["dep:bytemuck"]
 
 [dependencies]
+
+[dependencies.bytemuck]
+version = "1.19.0"
+optional = true
+default-features = false
 
 [dependencies.libm]
 version = "0.2.11"

--- a/color/README.md
+++ b/color/README.md
@@ -30,6 +30,7 @@ Color is a Rust crate which implements color space conversions, targeting at lea
 
 - `std` (enabled by default): Get floating point functions from the standard library (likely using your target's libc).
 - `libm`: Use floating point implementations from [libm][].
+- `bytemuck`: Implement traits from `bytemuck` on [`AlphaColor`], [`OpaqueColor`], [`PremulColor`], and [`Rgba8`].
 
 At least one of `std` and `libm` is required; `std` overrides `libm`.
 

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -22,6 +22,7 @@ use crate::floatfuncs::FloatFuncs;
 /// for spline interpolation. For cylindrical color spaces, hue fixup should
 /// be applied before interpolation.
 #[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
 pub struct OpaqueColor<CS> {
     /// The components, which may be manipulated directly.
     ///
@@ -37,6 +38,7 @@ pub struct OpaqueColor<CS> {
 ///
 /// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
 #[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
 pub struct AlphaColor<CS> {
     /// The components, which may be manipulated directly.
     ///
@@ -58,6 +60,7 @@ pub struct AlphaColor<CS> {
 ///
 /// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
 #[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
 pub struct PremulColor<CS> {
     /// The components, which may be manipulated directly.
     ///

--- a/color/src/impl_bytemuck.rs
+++ b/color/src/impl_bytemuck.rs
@@ -1,0 +1,131 @@
+// Copyright 2024 the Color Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![allow(unsafe_code, reason = "unsafe is required for bytemuck unsafe impls")]
+
+use crate::{AlphaColor, ColorSpace, OpaqueColor, PremulColor, Rgba8};
+
+// Safety: The struct is `repr(transparent)` and the data member is bytemuck::Pod.
+unsafe impl<CS: ColorSpace> bytemuck::Pod for AlphaColor<CS> {}
+
+// Safety: The struct is `repr(transparent)`.
+unsafe impl<CS: ColorSpace> bytemuck::TransparentWrapper<[f32; 4]> for AlphaColor<CS> {}
+
+// Safety: The struct is `repr(transparent)` and the data member is bytemuck::Zeroable.
+unsafe impl<CS: ColorSpace> bytemuck::Zeroable for AlphaColor<CS> {}
+
+// Safety: The struct is `repr(transparent)` and the data member is bytemuck::Pod.
+unsafe impl<CS: ColorSpace> bytemuck::Pod for OpaqueColor<CS> {}
+
+// Safety: The struct is `repr(transparent)`.
+unsafe impl<CS: ColorSpace> bytemuck::TransparentWrapper<[f32; 3]> for OpaqueColor<CS> {}
+
+// Safety: The struct is `repr(transparent)` and the data member is bytemuck::Zeroable.
+unsafe impl<CS: ColorSpace> bytemuck::Zeroable for OpaqueColor<CS> {}
+
+// Safety: The struct is `repr(transparent)` and the data member is bytemuck::Pod.
+unsafe impl<CS: ColorSpace> bytemuck::Pod for PremulColor<CS> {}
+
+// Safety: The struct is `repr(transparent)`.
+unsafe impl<CS: ColorSpace> bytemuck::TransparentWrapper<[f32; 4]> for PremulColor<CS> {}
+
+// Safety: The struct is `repr(transparent)` and the data member is bytemuck::Zeroable.
+unsafe impl<CS: ColorSpace> bytemuck::Zeroable for PremulColor<CS> {}
+
+// Safety: The struct is `repr(C)` and all members are bytemuck::Pod.
+unsafe impl bytemuck::Pod for Rgba8 {}
+
+// Safety: The struct is `repr(C)` and all members are bytemuck::Zeroable.
+unsafe impl bytemuck::Zeroable for Rgba8 {}
+
+#[cfg(test)]
+mod tests {
+    use crate::{AlphaColor, OpaqueColor, PremulColor, Rgba8, Srgb};
+    use bytemuck::{TransparentWrapper, Zeroable};
+    use core::marker::PhantomData;
+
+    fn assert_is_pod(_pod: impl bytemuck::Pod) {}
+
+    #[test]
+    fn alphacolor_is_pod() {
+        let AlphaColor {
+            components,
+            cs: PhantomData,
+        } = AlphaColor::<Srgb>::new([1., 2., 3., 0.]);
+        assert_is_pod(components);
+    }
+
+    #[test]
+    fn opaquecolor_is_pod() {
+        let OpaqueColor {
+            components,
+            cs: PhantomData,
+        } = OpaqueColor::<Srgb>::new([1., 2., 3.]);
+        assert_is_pod(components);
+    }
+
+    #[test]
+    fn premulcolor_is_pod() {
+        let PremulColor {
+            components,
+            cs: PhantomData,
+        } = PremulColor::<Srgb>::new([1., 2., 3., 0.]);
+        assert_is_pod(components);
+    }
+
+    #[test]
+    fn rgba8_is_pod() {
+        let rgba8 = Rgba8 {
+            r: 0,
+            b: 0,
+            g: 0,
+            a: 0,
+        };
+        let Rgba8 { r, g, b, a } = rgba8;
+        assert_is_pod(r);
+        assert_is_pod(g);
+        assert_is_pod(b);
+        assert_is_pod(a);
+    }
+
+    // If the inner type is wrong in the unsafe impl above,
+    // that will result in failures here due to assertions
+    // within bytemuck.
+    #[test]
+    fn transparent_wrapper() {
+        let ac = AlphaColor::<Srgb>::new([1., 2., 3., 0.]);
+        let ai: [f32; 4] = AlphaColor::<Srgb>::peel(ac);
+        assert_eq!(ai, [1., 2., 3., 0.]);
+
+        let oc = OpaqueColor::<Srgb>::new([1., 2., 3.]);
+        let oi: [f32; 3] = OpaqueColor::<Srgb>::peel(oc);
+        assert_eq!(oi, [1., 2., 3.]);
+
+        let pc = PremulColor::<Srgb>::new([1., 2., 3., 0.]);
+        let pi: [f32; 4] = PremulColor::<Srgb>::peel(pc);
+        assert_eq!(pi, [1., 2., 3., 0.]);
+    }
+
+    #[test]
+    fn zeroable() {
+        let ac = AlphaColor::<Srgb>::zeroed();
+        assert_eq!(ac.components, [0., 0., 0., 0.]);
+
+        let oc = OpaqueColor::<Srgb>::zeroed();
+        assert_eq!(oc.components, [0., 0., 0.]);
+
+        let pc = PremulColor::<Srgb>::zeroed();
+        assert_eq!(pc.components, [0., 0., 0., 0.]);
+
+        let rgba8 = Rgba8::zeroed();
+        assert_eq!(
+            rgba8,
+            Rgba8 {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 0
+            }
+        );
+    }
+}

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -20,6 +20,7 @@
 //!
 //! - `std` (enabled by default): Get floating point functions from the standard library (likely using your target's libc).
 //! - `libm`: Use floating point implementations from [libm][].
+//! - `bytemuck`: Implement traits from `bytemuck` on [`AlphaColor`], [`OpaqueColor`], [`PremulColor`], and [`Rgba8`].
 //!
 //! At least one of `std` and `libm` is required; `std` overrides `libm`.
 //!
@@ -40,6 +41,9 @@ mod rgba8;
 mod serialize;
 mod tag;
 mod x11_colors;
+
+#[cfg(feature = "bytemuck")]
+mod impl_bytemuck;
 
 #[cfg(all(not(feature = "std"), not(test)))]
 mod floatfuncs;

--- a/color/src/rgba8.rs
+++ b/color/src/rgba8.rs
@@ -9,6 +9,7 @@ use crate::{AlphaColor, Srgb};
 /// it is efficient and convenient, even if limited in accuracy and
 /// gamut.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(C)]
 pub struct Rgba8 {
     /// Red component.
     pub r: u8,


### PR DESCRIPTION
`AlphaColor`, `OpaqueColor`, and `PremulColor` are now using `#[repr(transparent)]` and impl the `bytemuck` traits `Pod`, `TransparentWrapper`, and `Zeroable`.

`Rgba8` is now `#[repr(C)]` and impls the `bytemuck` traits `Pod` and `Zeroable`.

The `bytemuck` traits are only available when the new `bytemuck` feature is enabled. It is not enabled by default.

This requires relaxing the forbidding of `unsafe_code` as the impls of the `bytemuck` traits must use `unsafe impl`.