### PR TITLE
Update `bytemuck` to 1.20 from 1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "color"

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -27,7 +27,7 @@ bytemuck = ["dep:bytemuck"]
 [dependencies]
 
 [dependencies.bytemuck]
-version = "1.19.0"
+version = "1.20.0"
 optional = true
 default-features = false
 


### PR DESCRIPTION
This is just following our tradition of requiring the same versions as in our lockfile.