### PR TITLE
Refer some AlphaColor method docs to OpaqueColor

### DIFF
--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -260,7 +260,7 @@ impl<CS: ColorSpace> OpaqueColor<CS> {
     /// let lighter = color.map_lightness(|l| l + 0.2);
     /// let expected = OpaqueColor::<Lab>::new([60., 4., -17.]);
     ///
-    /// assert!(lighter.difference(expected) < 0.001);
+    /// assert!(lighter.difference(expected) < 1e-4);
     /// ```
     ///
     /// [Lab]: crate::Lab
@@ -294,7 +294,7 @@ impl<CS: ColorSpace> OpaqueColor<CS> {
     /// let complementary = color.map_hue(|h| (h + 180.) % 360.);
     /// let expected = OpaqueColor::<Oklab>::new([0.5, -0.2, 0.1]);
     ///
-    /// assert!(complementary.difference(expected) < 0.001);
+    /// assert!(complementary.difference(expected) < 1e-4);
     /// ```
     #[must_use]
     pub fn map_hue(self, f: impl Fn(f32) -> f32) -> Self {
@@ -461,7 +461,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
     /// let lighter = color.map_lightness(|l| l + 0.2);
     /// let expected = AlphaColor::<Lab>::new([60., 4., -17., 1.]);
     ///
-    /// assert!(lighter.discard_alpha().difference(expected.discard_alpha()) < 0.001);
+    /// assert!(lighter.discard_alpha().difference(expected.discard_alpha()) < 1e-4);
     /// ```
     ///
     /// [Lab]: crate::Lab
@@ -495,7 +495,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
     /// let complementary = color.map_hue(|h| (h + 180.) % 360.);
     /// let expected = AlphaColor::<Oklab>::new([0.5, -0.2, 0.1, 1.]);
     ///
-    /// assert!(complementary.discard_alpha().difference(expected.discard_alpha()) < 0.001);
+    /// assert!(complementary.discard_alpha().difference(expected.discard_alpha()) < 1e-4);
     /// ```
     #[must_use]
     pub fn map_hue(self, f: impl Fn(f32) -> f32) -> Self {

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -447,7 +447,26 @@ impl<CS: ColorSpace> AlphaColor<CS> {
 
     /// Map the lightness of the color.
     ///
-    /// See [`OpaqueColor::map_lightness`] for more details.
+    /// In a color space that naturally has a lightness component, map that value.
+    /// Otherwise, do the mapping in [Oklab]. The lightness range is normalized so
+    /// that 1.0 is white. That is the normal range for Oklab but differs from the
+    /// range in [Lab], [Lch], and [Hsl].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use color::{AlphaColor, Lab};
+    ///
+    /// let color = AlphaColor::<Lab>::new([40., 4., -17., 1.]);
+    /// let lighter = color.map_lightness(|l| l + 0.2);
+    /// let expected = AlphaColor::<Lab>::new([60., 4., -17., 1.]);
+    ///
+    /// assert!(lighter.discard_alpha().difference(expected.discard_alpha()) < 0.001);
+    /// ```
+    ///
+    /// [Lab]: crate::Lab
+    /// [Lch]: crate::Lch
+    /// [Hsl]: crate::Hsl
     #[must_use]
     pub fn map_lightness(self, f: impl Fn(f32) -> f32) -> Self {
         match CS::TAG {
@@ -464,7 +483,20 @@ impl<CS: ColorSpace> AlphaColor<CS> {
 
     /// Map the hue of the color.
     ///
-    /// See [`OpaqueColor::map_hue`] for more details.
+    /// In a color space that naturally has a hue component, map that value.
+    /// Otherwise, do the mapping in [Oklch]. The hue is in degrees.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use color::{AlphaColor, Oklab};
+    ///
+    /// let color = AlphaColor::<Oklab>::new([0.5, 0.2, -0.1, 1.]);
+    /// let complementary = color.map_hue(|h| (h + 180.) % 360.);
+    /// let expected = AlphaColor::<Oklab>::new([0.5, -0.2, 0.1, 1.]);
+    ///
+    /// assert!(complementary.discard_alpha().difference(expected.discard_alpha()) < 0.001);
+    /// ```
     #[must_use]
     pub fn map_hue(self, f: impl Fn(f32) -> f32) -> Self {
         match CS::LAYOUT {

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -248,7 +248,7 @@ impl<CS: ColorSpace> OpaqueColor<CS> {
     ///
     /// In a color space that naturally has a lightness component, map that value.
     /// Otherwise, do the mapping in [Oklab]. The lightness range is normalized so
-    /// that 1.0 is white. That is the normal range for Oklab but differs from the
+    /// that 1.0 is white. That is the normal range for [Oklab] but differs from the
     /// range in [Lab], [Lch], and [Hsl].
     ///
     /// # Examples
@@ -449,7 +449,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
     ///
     /// In a color space that naturally has a lightness component, map that value.
     /// Otherwise, do the mapping in [Oklab]. The lightness range is normalized so
-    /// that 1.0 is white. That is the normal range for Oklab but differs from the
+    /// that 1.0 is white. That is the normal range for [Oklab] but differs from the
     /// range in [Lab], [Lch], and [Hsl].
     ///
     /// # Examples

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -447,14 +447,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
 
     /// Map the lightness of the color.
     ///
-    /// In a color space that naturally has a lightness component, map that value.
-    /// Otherwise, do the mapping in [Oklab]. The lightness range is normalized so
-    /// that 1.0 is white. That is the normal range for [Oklab] but differs from the
-    /// range in [Lab], [Lch], and [Hsl].
-    ///
-    /// [Lab]: crate::Lab
-    /// [Lch]: crate::Lch
-    /// [Hsl]: crate::Hsl
+    /// See [`OpaqueColor::map_lightness`] for more details.
     #[must_use]
     pub fn map_lightness(self, f: impl Fn(f32) -> f32) -> Self {
         match CS::TAG {
@@ -471,8 +464,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
 
     /// Map the hue of the color.
     ///
-    /// In a color space that naturally has a hue component, map that value.
-    /// Otherwise, do the mapping in [Oklch]. The hue is in degrees.
+    /// See [`OpaqueColor::map_hue`] for more details.
     #[must_use]
     pub fn map_hue(self, f: impl Fn(f32) -> f32) -> Self {
         match CS::LAYOUT {

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -461,7 +461,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
     /// let lighter = color.map_lightness(|l| l + 0.2);
     /// let expected = AlphaColor::<Lab>::new([60., 4., -17., 1.]);
     ///
-    /// assert!(lighter.discard_alpha().difference(expected.discard_alpha()) < 1e-4);
+    /// assert!(lighter.premultiply().difference(expected.premultiply()) < 1e-4);
     /// ```
     ///
     /// [Lab]: crate::Lab
@@ -495,7 +495,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
     /// let complementary = color.map_hue(|h| (h + 180.) % 360.);
     /// let expected = AlphaColor::<Oklab>::new([0.5, -0.2, 0.1, 1.]);
     ///
-    /// assert!(complementary.discard_alpha().difference(expected.discard_alpha()) < 1e-4);
+    /// assert!(complementary.premultiply().difference(expected.premultiply()) < 1e-4);
     /// ```
     #[must_use]
     pub fn map_hue(self, f: impl Fn(f32) -> f32) -> Self {


### PR DESCRIPTION
This links to the examples, and prevents having to duplicate/keep-in-sync the documentation.