### PR TITLE
Optionally support `serde`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This release has an [MSRV][] of 1.82.
 ### Added
 
 * Add `BLACK`, `WHITE`, and `TRANSPARENT` constants to the color types. ([#64][] by [@waywardmonkeys][])
+* The `serde` feature enables using `serde` with `AlphaColor`, `OpaqueColor`, `PremulColor`, and `Rgba8`. ([#61][] by [@waywardmonkeys][])
 
 ### Changed
 
@@ -31,6 +32,7 @@ This is the initial release.
 
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 
+[#61]: https://github.com/linebender/color/pull/61
 [#64]: https://github.com/linebender/color/pull/64
 [#65]: https://github.com/linebender/color/pull/65
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "libm",
+ "serde",
 ]
 
 [[package]]
@@ -28,3 +29,58 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -17,9 +17,10 @@ targets = []
 
 [features]
 default = ["std"]
-std = []
+std = ["serde?/std"]
 libm = ["dep:libm"]
 bytemuck = ["dep:bytemuck"]
+serde = ["dep:serde"]
 
 [dependencies]
 
@@ -31,6 +32,12 @@ default-features = false
 [dependencies.libm]
 version = "0.2.11"
 optional = true
+
+[dependencies.serde]
+version = "1.0.215"
+optional = true
+default-features = false
+features = ["derive"]
 
 [lints]
 workspace = true

--- a/color/README.md
+++ b/color/README.md
@@ -92,6 +92,8 @@ this trait for new color spaces.
 - `libm`: Use floating point implementations from [libm][].
 - `bytemuck`: Implement traits from `bytemuck` on [`AlphaColor`], [`OpaqueColor`],
   [`PremulColor`], and [`Rgba8`].
+- `serde`: Implement `serde::Deserialize` and `serde::Serialize` on [`AlphaColor`],
+  [`OpaqueColor`], [`PremulColor`], and [`Rgba8`].
 
 At least one of `std` and `libm` is required; `std` overrides `libm`.
 

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -22,6 +22,7 @@ use crate::floatfuncs::FloatFuncs;
 /// for spline interpolation. For cylindrical color spaces, hue fixup should
 /// be applied before interpolation.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[repr(transparent)]
 pub struct OpaqueColor<CS> {
     /// The components, which may be manipulated directly.
@@ -38,6 +39,7 @@ pub struct OpaqueColor<CS> {
 ///
 /// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[repr(transparent)]
 pub struct AlphaColor<CS> {
     /// The components, which may be manipulated directly.
@@ -60,6 +62,7 @@ pub struct AlphaColor<CS> {
 ///
 /// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[repr(transparent)]
 pub struct PremulColor<CS> {
     /// The components, which may be manipulated directly.

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -63,6 +63,8 @@
 //! - `libm`: Use floating point implementations from [libm][].
 //! - `bytemuck`: Implement traits from `bytemuck` on [`AlphaColor`], [`OpaqueColor`],
 //!   [`PremulColor`], and [`Rgba8`].
+//! - `serde`: Implement `serde::Deserialize` and `serde::Serialize` on [`AlphaColor`],
+//!   [`OpaqueColor`], [`PremulColor`], and [`Rgba8`].
 //!
 //! At least one of `std` and `libm` is required; `std` overrides `libm`.
 //!

--- a/color/src/rgba8.rs
+++ b/color/src/rgba8.rs
@@ -9,6 +9,7 @@ use crate::{AlphaColor, Srgb};
 /// it is efficient and convenient, even if limited in accuracy and
 /// gamut.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[repr(C)]
 pub struct Rgba8 {
     /// Red component.


### PR DESCRIPTION
This adds support for `serde::Deserialize` and `serde::Serialize` using `serde-derive` for `AlphaColor`, `OpaqueColor`, `PremulColor`, `Rgba8`.

This does not provide it for `DynamicColor` to avoid dealing with the non-exhaustive `ColorSpaceTag`.

It uses `derive` rather than hand-implementing the traits as the latter is very verbose and most things using `serde` will already have enabled the `derive` feature. (This is also true for the other Linebender crates.)