### PR TITLE
Rename `mul_alpha` to `multiply_alpha`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This release has an [MSRV][] of 1.82.
 
 * Add `BLACK`, `WHITE`, and `TRANSPARENT` constants to the color types. ([#64][] by [@waywardmonkeys][])
 
+### Changed
+
+* The `mul_alpha` method was renamed to `multiply_alpha`. ([#65][] by [@waywardmonkeys][])
+
 ## [0.1.0][] (2024-11-20)
 
 This release has an [MSRV][] of 1.82.
@@ -28,6 +32,7 @@ This is the initial release.
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 
 [#64]: https://github.com/linebender/color/pull/64
+[#65]: https://github.com/linebender/color/pull/65
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -387,7 +387,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
 
     /// Multiply alpha by the given factor.
     #[must_use]
-    pub const fn mul_alpha(self, rhs: f32) -> Self {
+    pub const fn multiply_alpha(self, rhs: f32) -> Self {
         let (opaque, alpha) = split_alpha(self.components);
         Self::new(add_alpha(opaque, alpha * rhs))
     }
@@ -555,7 +555,7 @@ impl<CS: ColorSpace> PremulColor<CS> {
 
     /// Multiply alpha by the given factor.
     #[must_use]
-    pub const fn mul_alpha(self, rhs: f32) -> Self {
+    pub const fn multiply_alpha(self, rhs: f32) -> Self {
         let (multiplied, alpha) = split_alpha(self.components);
         Self::new(add_alpha(CS::LAYOUT.scale(multiplied, rhs), alpha * rhs))
     }
@@ -686,7 +686,7 @@ impl<CS: ColorSpace> core::ops::Sub for AlphaColor<CS> {
 /// Multiply components by a scalar.
 ///
 /// For rectangular color spaces, this is equivalent to multiplying
-/// alpha, but for cylindrical color spaces, [`PremulColor::mul_alpha`]
+/// alpha, but for cylindrical color spaces, [`PremulColor::multiply_alpha`]
 /// is the preferred method.
 impl<CS: ColorSpace> core::ops::Mul<f32> for PremulColor<CS> {
     type Output = Self;


### PR DESCRIPTION
This better fits with the naming scheme in other Linebender crates.

Fixes #62.