### PR TITLE
Add `AlphaColor::with_alpha`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This release has an [MSRV][] of 1.82.
 * The `serde` feature enables using `serde` with `AlphaColor`, `OpaqueColor`, `PremulColor`, and `Rgba8`. ([#61][] by [@waywardmonkeys][])
 * Conversion of a `Rgba8` to a `u32` is now provided. ([#66][] by [@waywardmonkeys][])
 * A new `PremulRgba8` type mirrors `Rgba8`, but for `PremulColor`. ([#66][] by [@waywardmonkeys][])
+* `AlphaColor::with_alpha` allows setting the alpha channel. ([#67][] by [@waywardmonkeys][])
 
 ### Changed
 
@@ -38,6 +39,7 @@ This is the initial release.
 [#64]: https://github.com/linebender/color/pull/64
 [#65]: https://github.com/linebender/color/pull/65
 [#66]: https://github.com/linebender/color/pull/66
+[#67]: https://github.com/linebender/color/pull/67
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -346,6 +346,22 @@ impl<CS: ColorSpace> AlphaColor<CS> {
         (OpaqueColor::new(opaque), alpha)
     }
 
+    /// Set the alpha channel.
+    ///
+    /// This replaces the existing alpha channel. To scale or
+    /// or otherwise modify the existing alpha channel, use
+    /// [`AlphaColor::multiply_alpha`] or [`AlphaColor::map`].
+    ///
+    /// ```
+    /// let c = color::palette::css::GOLDENROD.with_alpha(0.5);
+    /// assert_eq!(0.5, c.split().1);
+    /// ```
+    #[must_use]
+    pub const fn with_alpha(self, alpha: f32) -> Self {
+        let (opaque, _alpha) = split_alpha(self.components);
+        Self::new(add_alpha(opaque, alpha))
+    }
+
     /// Split out the opaque components, discarding the alpha.
     ///
     /// This is a shorthand for calling [`split`](Self::split).


### PR DESCRIPTION
This is similar to `OpaqueColor::with_alpha`, but allows modifying the alpha channel on an `AlphaColor`.

This can be done via `map`, but this is `const`, so it can result in better code in scenarios like:

```
    let c = color::palette::css::GOLDENROD.with_alpha(0.5);
```