### PR TITLE
Impl `serde` for `DynamicColor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This release has an [MSRV][] of 1.82.
 ### Added
 
 * Add `BLACK`, `WHITE`, and `TRANSPARENT` constants to the color types. ([#64][] by [@waywardmonkeys][])
-* The `serde` feature enables using `serde` with `AlphaColor`, `OpaqueColor`, `PremulColor`, and `Rgba8`. ([#61][] by [@waywardmonkeys][])
+* The `serde` feature enables using `serde` with `AlphaColor`, `DynamicColor`, `OpaqueColor`, `PremulColor`, and `Rgba8`. ([#61][], [#70][] by [@waywardmonkeys][])
 * Conversion of a `Rgba8` to a `u32` is now provided. ([#66][] by [@waywardmonkeys][])
 * A new `PremulRgba8` type mirrors `Rgba8`, but for `PremulColor`. ([#66][] by [@waywardmonkeys][])
 * `AlphaColor::with_alpha` allows setting the alpha channel. ([#67][] by [@waywardmonkeys][])
@@ -40,6 +40,7 @@ This is the initial release.
 [#65]: https://github.com/linebender/color/pull/65
 [#66]: https://github.com/linebender/color/pull/66
 [#67]: https://github.com/linebender/color/pull/67
+[#70]: https://github.com/linebender/color/pull/70
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -26,6 +26,7 @@ use crate::{
 ///
 /// [Oklch]: crate::Oklch
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DynamicColor {
     /// The color space.
     pub cs: ColorSpaceTag,

--- a/color/src/missing.rs
+++ b/color/src/missing.rs
@@ -5,6 +5,7 @@
 
 /// A simple bitset for representing missing components.
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Missing(u8);
 
 impl Missing {

--- a/color/src/tag.rs
+++ b/color/src/tag.rs
@@ -18,6 +18,7 @@ use crate::{
 ///
 /// Note: when adding an RGB-like color space, add to `same_analogous`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
 pub enum ColorSpaceTag {
     /// The [`Srgb`] color space.


### PR DESCRIPTION
Using `DynamicColor` for color stops in Peniko will require this (when Peniko's `serde` feature is enabled).