### PR TITLE
Add `with_alpha` and `multiply_alpha` on `DynamicColor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This release has an [MSRV][] of 1.82.
 * A new `PremulRgba8` type mirrors `Rgba8`, but for `PremulColor`. ([#66][] by [@waywardmonkeys][])
 * `AlphaColor::with_alpha` allows setting the alpha channel. ([#67][] by [@waywardmonkeys][])
 * Support for the `ACEScg` colorspace. ([#54][] by [@MightyBurger][])
+* `DynamicColor` gets `with_alpha` and `multiply_alpha`. ([#71][] by [@waywardmonkeys][])
 
 ### Changed
 
@@ -44,6 +45,7 @@ This is the initial release.
 [#66]: https://github.com/linebender/color/pull/66
 [#67]: https://github.com/linebender/color/pull/67
 [#70]: https://github.com/linebender/color/pull/70
+[#71]: https://github.com/linebender/color/pull/71
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0

--- a/color/src/missing.rs
+++ b/color/src/missing.rs
@@ -10,7 +10,7 @@ pub struct Missing(u8);
 
 impl Missing {
     /// Returns `true` if the set contains the component index.
-    pub fn contains(self, ix: usize) -> bool {
+    pub const fn contains(self, ix: usize) -> bool {
         (self.0 & (1 << ix)) != 0
     }
 
@@ -20,12 +20,12 @@ impl Missing {
     }
 
     /// The set containing a single component index.
-    pub fn single(ix: usize) -> Self {
+    pub const fn single(ix: usize) -> Self {
         Self(1 << ix)
     }
 
     /// Returns `true` if the set contains no indices.
-    pub fn is_empty(self) -> bool {
+    pub const fn is_empty(self) -> bool {
         self.0 == 0
     }
 }


### PR DESCRIPTION
If the alpha channel is missing, these operations will do nothing.

Additionally, mark some functions on `Missing` as `const`.