### PR TITLE
Implement `Hash`, `PartialEq` for `DynamicColor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This release has an [MSRV][] of 1.82.
 * `AlphaColor::with_alpha` allows setting the alpha channel. ([#67][] by [@waywardmonkeys][])
 * Support for the `ACEScg` colorspace. ([#54][] by [@MightyBurger][])
 * `DynamicColor` gets `with_alpha` and `multiply_alpha`. ([#71][] by [@waywardmonkeys][])
+* `DynamicColor` now impls `Hash` and `PartialEq`. ([#75][] by [@waywardmonkeys][])
 
 ### Changed
 
@@ -46,6 +47,7 @@ This is the initial release.
 [#67]: https://github.com/linebender/color/pull/67
 [#70]: https://github.com/linebender/color/pull/70
 [#71]: https://github.com/linebender/color/pull/71
+[#75]: https://github.com/linebender/color/pull/75
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0

--- a/color/src/missing.rs
+++ b/color/src/missing.rs
@@ -4,7 +4,7 @@
 //! A simple bitset.
 
 /// A simple bitset for representing missing components.
-#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Missing(u8);
 

--- a/color/src/tag.rs
+++ b/color/src/tag.rs
@@ -17,7 +17,7 @@ use crate::{
 /// Note: this has some tags not yet implemented.
 ///
 /// Note: when adding an RGB-like color space, add to `same_analogous`.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
 pub enum ColorSpaceTag {


### PR DESCRIPTION
Also, impl `Hash` on `ColorSpaceTag`, `Missing` in support.

This is useful for using `DynamicColor` within a cache key or for memoizing, but does not match the behavior of Rust float types.