### PR TITLE
`(Premul)Rgba8::to_u32` now returns in little endian format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This release has an [MSRV][] of 1.82.
 
 * Add `BLACK`, `WHITE`, and `TRANSPARENT` constants to the color types. ([#64][] by [@waywardmonkeys][])
 * The `serde` feature enables using `serde` with `AlphaColor`, `DynamicColor`, `OpaqueColor`, `PremulColor`, and `Rgba8`. ([#61][], [#70][] by [@waywardmonkeys][])
-* Conversion of a `Rgba8` to a `u32` is now provided. ([#66][] by [@waywardmonkeys][])
+* Conversion of a `Rgba8` to a `u32` is now provided. ([#66][], [#77][] by [@waywardmonkeys][])
 * A new `PremulRgba8` type mirrors `Rgba8`, but for `PremulColor`. ([#66][] by [@waywardmonkeys][])
 * `AlphaColor::with_alpha` allows setting the alpha channel. ([#67][] by [@waywardmonkeys][])
 * Support for the `ACEScg` colorspace. ([#54][] by [@MightyBurger][])
@@ -48,6 +48,7 @@ This is the initial release.
 [#70]: https://github.com/linebender/color/pull/70
 [#71]: https://github.com/linebender/color/pull/71
 [#75]: https://github.com/linebender/color/pull/75
+[#77]: https://github.com/linebender/color/pull/77
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0

--- a/color/src/rgba8.rs
+++ b/color/src/rgba8.rs
@@ -25,11 +25,17 @@ pub struct Rgba8 {
 }
 
 impl Rgba8 {
-    /// Returns the color as a packed value, with `r` as the most significant byte and
-    /// `a` the least.
+    /// Returns the color as a `[u8; 4]`.
+    #[must_use]
+    pub const fn to_u8_array(self) -> [u8; 4] {
+        [self.r, self.g, self.b, self.a]
+    }
+
+    /// Returns the color as a little endian packed value, with `a` as the
+    /// most significant byte and `r` the least.
     #[must_use]
     pub const fn to_u32(self) -> u32 {
-        u32::from_be_bytes([self.r, self.g, self.b, self.a])
+        u32::from_le_bytes(self.to_u8_array())
     }
 }
 
@@ -59,11 +65,17 @@ pub struct PremulRgba8 {
 }
 
 impl PremulRgba8 {
-    /// Returns the color as a packed value, with `r` as the most significant byte and
-    /// `a` the least.
+    /// Returns the color as a `[u8; 4]`.
+    #[must_use]
+    pub const fn to_u8_array(self) -> [u8; 4] {
+        [self.r, self.g, self.b, self.a]
+    }
+
+    /// Returns the color as a little endian packed value, with `a` as the
+    /// most significant byte and `r` the least.
     #[must_use]
     pub const fn to_u32(self) -> u32 {
-        u32::from_be_bytes([self.r, self.g, self.b, self.a])
+        u32::from_le_bytes(self.to_u8_array())
     }
 }
 
@@ -85,7 +97,7 @@ mod tests {
             b: 3,
             a: 4,
         };
-        assert_eq!(0x01020304_u32, c.to_u32());
+        assert_eq!(0x04030201_u32, c.to_u32());
 
         let p = PremulRgba8 {
             r: 0xaa,
@@ -93,6 +105,6 @@ mod tests {
             b: 0xcc,
             a: 0xff,
         };
-        assert_eq!(0xaabbccff_u32, p.to_u32());
+        assert_eq!(0xffccbbaa_u32, p.to_u32());
     }
 }


### PR DESCRIPTION
This matches the WebGPU spec which states that the internal layout of values is such that values in host-shared buffers are stored in little-endian format: https://www.w3.org/TR/WGSL/#internal-value-layout