### PR TITLE
Add `serde` for `HueDirection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This release has an [MSRV][] of 1.82.
 ### Added
 
 * Add `BLACK`, `WHITE`, and `TRANSPARENT` constants to the color types. ([#64][] by [@waywardmonkeys][])
-* The `serde` feature enables using `serde` with `AlphaColor`, `DynamicColor`, `OpaqueColor`, `PremulColor`, and `Rgba8`. ([#61][], [#70][] by [@waywardmonkeys][])
+* The `serde` feature enables using `serde` with `AlphaColor`, `DynamicColor`, `HueDirection`, `OpaqueColor`, `PremulColor`, and `Rgba8`. ([#61][], [#70][], [#80][] by [@waywardmonkeys][])
 * Conversion of a `Rgba8` to a `u32` is now provided. ([#66][], [#77][] by [@waywardmonkeys][])
 * A new `PremulRgba8` type mirrors `Rgba8`, but for `PremulColor`. ([#66][] by [@waywardmonkeys][])
 * `AlphaColor::with_alpha` allows setting the alpha channel. ([#67][] by [@waywardmonkeys][])
@@ -57,6 +57,7 @@ This is the initial release.
 [#77]: https://github.com/linebender/color/pull/77
 [#78]: https://github.com/linebender/color/pull/78
 [#79]: https://github.com/linebender/color/pull/79
+[#80]: https://github.com/linebender/color/pull/80
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -87,6 +87,7 @@ pub struct PremulColor<CS> {
 ///
 /// [`hue-interpolation-method`]: https://developer.mozilla.org/en-US/docs/Web/CSS/hue-interpolation-method
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
 pub enum HueDirection {
     /// Hue angles take the shorter of the two arcs between starting and ending values.


### PR DESCRIPTION
This is needed for adding `HueDirection` to `Gradient` in Peniko.