### PR TITLE
Add `bytemuck` support for `HueDirection`, and `ColorSpaceTag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This release has an [MSRV][] of 1.82.
 * `DynamicColor` gets `with_alpha` and `multiply_alpha`. ([#71][] by [@waywardmonkeys][])
 * `DynamicColor` now impls `Hash` and `PartialEq`. ([#75][] by [@waywardmonkeys][])
 * `HueDirection` now impls `PartialEq`. ([#79][] by [@waywardmonkeys][])
+* `ColorSpaceTag` and `HueDirection` now have bytemuck support. ([#81][] by [@waywardmonkeys][])
 
 ### Changed
 
@@ -58,6 +59,7 @@ This is the initial release.
 [#78]: https://github.com/linebender/color/pull/78
 [#79]: https://github.com/linebender/color/pull/79
 [#80]: https://github.com/linebender/color/pull/80
+[#81]: https://github.com/linebender/color/pull/80
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0

--- a/color/README.md
+++ b/color/README.md
@@ -91,8 +91,8 @@ this trait for new color spaces.
 - `std` (enabled by default): Get floating point functions from the standard library
   (likely using your target's libc).
 - `libm`: Use floating point implementations from [libm][].
-- `bytemuck`: Implement traits from `bytemuck` on [`AlphaColor`], [`OpaqueColor`],
-  [`PremulColor`], [`PremulRgba8`], and [`Rgba8`].
+- `bytemuck`: Implement traits from `bytemuck` on [`AlphaColor`], [`ColorSpaceTag`],
+  [`HueDirection`], [`OpaqueColor`], [`PremulColor`], [`PremulRgba8`], and [`Rgba8`].
 - `serde`: Implement `serde::Deserialize` and `serde::Serialize` on [`AlphaColor`],
   [`OpaqueColor`], [`PremulColor`], [`PremulRgba8`], and [`Rgba8`].
 

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -89,17 +89,19 @@ pub struct PremulColor<CS> {
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
+#[repr(u8)]
 pub enum HueDirection {
     /// Hue angles take the shorter of the two arcs between starting and ending values.
     #[default]
-    Shorter,
+    Shorter = 0,
     /// Hue angles take the longer of the two arcs between starting and ending values.
-    Longer,
+    Longer = 1,
     /// Hue angles increase as they are interpolated.
-    Increasing,
+    Increasing = 2,
     /// Hue angles decrease as they are interpolated.
-    Decreasing,
+    Decreasing = 3,
     // It's possible we'll add "raw"; color.js has it.
+    // NOTICE: If a new value is added, be sure to add modify `MAX_VALUE` in the bytemuck impl.
 }
 
 /// Fixup hue based on specified hue direction.

--- a/color/src/impl_bytemuck.rs
+++ b/color/src/impl_bytemuck.rs
@@ -3,7 +3,10 @@
 
 #![allow(unsafe_code, reason = "unsafe is required for bytemuck unsafe impls")]
 
-use crate::{AlphaColor, ColorSpace, OpaqueColor, PremulColor, PremulRgba8, Rgba8};
+use crate::{
+    AlphaColor, ColorSpace, ColorSpaceTag, HueDirection, OpaqueColor, PremulColor, PremulRgba8,
+    Rgba8,
+};
 
 // Safety: The struct is `repr(transparent)` and the data member is bytemuck::Pod.
 unsafe impl<CS: ColorSpace> bytemuck::Pod for AlphaColor<CS> {}
@@ -44,10 +47,62 @@ unsafe impl bytemuck::Pod for Rgba8 {}
 // Safety: The struct is `repr(C)` and all members are bytemuck::Zeroable.
 unsafe impl bytemuck::Zeroable for Rgba8 {}
 
+// Safety: The enum is `repr(u8)` and has only fieldless variants.
+unsafe impl bytemuck::NoUninit for ColorSpaceTag {}
+
+// Safety: The enum is `repr(u8)` and `0` is a valid value.
+unsafe impl bytemuck::Zeroable for ColorSpaceTag {}
+
+// Safety: The enum is `repr(u8)`.
+unsafe impl bytemuck::checked::CheckedBitPattern for ColorSpaceTag {
+    type Bits = u8;
+
+    fn is_valid_bit_pattern(bits: &u8) -> bool {
+        use bytemuck::Contiguous;
+        // Don't need to compare against MIN_VALUE as this is u8 and 0 is the MIN_VALUE.
+        *bits <= Self::MAX_VALUE
+    }
+}
+
+// Safety: The enum is `repr(u8)`. All values are `u8` and fall within
+// the min and max values.
+unsafe impl bytemuck::Contiguous for ColorSpaceTag {
+    type Int = u8;
+    const MIN_VALUE: u8 = Self::Srgb as u8;
+    const MAX_VALUE: u8 = Self::XyzD65 as u8;
+}
+
+// Safety: The enum is `repr(u8)` and has only fieldless variants.
+unsafe impl bytemuck::NoUninit for HueDirection {}
+
+// Safety: The enum is `repr(u8)` and `0` is a valid value.
+unsafe impl bytemuck::Zeroable for HueDirection {}
+
+// Safety: The enum is `repr(u8)`.
+unsafe impl bytemuck::checked::CheckedBitPattern for HueDirection {
+    type Bits = u8;
+
+    fn is_valid_bit_pattern(bits: &u8) -> bool {
+        use bytemuck::Contiguous;
+        // Don't need to compare against MIN_VALUE as this is u8 and 0 is the MIN_VALUE.
+        *bits <= Self::MAX_VALUE
+    }
+}
+
+// Safety: The enum is `repr(u8)`. All values are `u8` and fall within
+// the min and max values.
+unsafe impl bytemuck::Contiguous for HueDirection {
+    type Int = u8;
+    const MIN_VALUE: u8 = Self::Shorter as u8;
+    const MAX_VALUE: u8 = Self::Decreasing as u8;
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{AlphaColor, OpaqueColor, PremulColor, PremulRgba8, Rgba8, Srgb};
-    use bytemuck::{TransparentWrapper, Zeroable};
+    use crate::{
+        AlphaColor, ColorSpaceTag, HueDirection, OpaqueColor, PremulColor, PremulRgba8, Rgba8, Srgb,
+    };
+    use bytemuck::{checked::try_from_bytes, Contiguous, TransparentWrapper, Zeroable};
     use core::marker::PhantomData;
 
     fn assert_is_pod(_pod: impl bytemuck::Pod) {}
@@ -109,6 +164,41 @@ mod tests {
         assert_is_pod(a);
     }
 
+    #[test]
+    fn checked_bit_pattern() {
+        let valid = bytemuck::bytes_of(&2_u8);
+        let invalid = bytemuck::bytes_of(&200_u8);
+
+        assert_eq!(
+            Ok(&ColorSpaceTag::Lab),
+            try_from_bytes::<ColorSpaceTag>(valid)
+        );
+
+        assert!(try_from_bytes::<ColorSpaceTag>(invalid).is_err());
+
+        assert_eq!(
+            Ok(&HueDirection::Increasing),
+            try_from_bytes::<HueDirection>(valid)
+        );
+
+        assert!(try_from_bytes::<HueDirection>(invalid).is_err());
+    }
+
+    #[test]
+    fn contiguous() {
+        let cst1 = ColorSpaceTag::LinearSrgb;
+        let cst2 = ColorSpaceTag::from_integer(cst1.into_integer());
+        assert_eq!(Some(cst1), cst2);
+
+        assert_eq!(None, ColorSpaceTag::from_integer(255));
+
+        let hd1 = HueDirection::Decreasing;
+        let hd2 = HueDirection::from_integer(hd1.into_integer());
+        assert_eq!(Some(hd1), hd2);
+
+        assert_eq!(None, HueDirection::from_integer(255));
+    }
+
     // If the inner type is wrong in the unsafe impl above,
     // that will result in failures here due to assertions
     // within bytemuck.
@@ -148,5 +238,11 @@ mod tests {
                 a: 0
             }
         );
+
+        let cst = ColorSpaceTag::zeroed();
+        assert_eq!(cst, ColorSpaceTag::Srgb);
+
+        let hd = HueDirection::zeroed();
+        assert_eq!(hd, HueDirection::Shorter);
     }
 }

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -62,8 +62,8 @@
 //! - `std` (enabled by default): Get floating point functions from the standard library
 //!   (likely using your target's libc).
 //! - `libm`: Use floating point implementations from [libm][].
-//! - `bytemuck`: Implement traits from `bytemuck` on [`AlphaColor`], [`OpaqueColor`],
-//!   [`PremulColor`], [`PremulRgba8`], and [`Rgba8`].
+//! - `bytemuck`: Implement traits from `bytemuck` on [`AlphaColor`], [`ColorSpaceTag`],
+//!   [`HueDirection`], [`OpaqueColor`], [`PremulColor`], [`PremulRgba8`], and [`Rgba8`].
 //! - `serde`: Implement `serde::Deserialize` and `serde::Serialize` on [`AlphaColor`],
 //!   [`OpaqueColor`], [`PremulColor`], [`PremulRgba8`], and [`Rgba8`].
 //!

--- a/color/src/tag.rs
+++ b/color/src/tag.rs
@@ -20,37 +20,39 @@ use crate::{
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
+#[repr(u8)]
 pub enum ColorSpaceTag {
     /// The [`Srgb`] color space.
-    Srgb,
+    Srgb = 0,
     /// The [`LinearSrgb`] color space.
-    LinearSrgb,
+    LinearSrgb = 1,
     /// The [`Lab`] color space.
-    Lab,
+    Lab = 2,
     /// The [`Lch`] color space.
-    Lch,
+    Lch = 3,
     /// The [`Hsl`] color space.
-    Hsl,
+    Hsl = 4,
     /// The [`Hwb`] color space.
-    Hwb,
+    Hwb = 5,
     /// The [`Oklab`] color space.
-    Oklab,
+    Oklab = 6,
     /// The [`Oklch`] color space.
-    Oklch,
+    Oklch = 7,
     /// The [`DisplayP3`] color space.
-    DisplayP3,
+    DisplayP3 = 8,
     /// The [`A98Rgb`] color space.
-    A98Rgb,
+    A98Rgb = 9,
     /// The [`ProphotoRgb`] color space.
-    ProphotoRgb,
+    ProphotoRgb = 10,
     /// The [`Rec2020`] color space.
-    Rec2020,
+    Rec2020 = 11,
     /// The [`AcesCg`] color space.
-    AcesCg,
+    AcesCg = 12,
     /// The [`XyzD50`] color space.
-    XyzD50,
+    XyzD50 = 13,
     /// The [`XyzD65`] color space.
-    XyzD65,
+    XyzD65 = 14,
+    // NOTICE: If a new value is added, be sure to add modify `MAX_VALUE` in the bytemuck impl.
 }
 
 impl ColorSpaceTag {


### PR DESCRIPTION
These now impl `CheckedBitPattern`, `Contiguous`, `NoUninit`, and `Zeroable`. They do not impl `Pod` as they are only valid for a subset of the bit patterns.

Additionally, these types are now `repr(u8)` and have directly assigned integer values so that we can be sure that the impl of the `Contiguous` trait is correct.

This will likely be useful when working with gradients in Vello and it has to encode things to the draw stream.

It may also be useful when we're doing a C FFI in the future.