### PR TITLE
Default color types to opaque white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This release has an [MSRV][] of 1.82.
 * `AlphaColor`, `OpaqueColor`, and `PremulColor` now impl `PartialEq`. ([#76][], [#86][] by [@waywardmonkeys][])
 * `HueDirection` now impls `PartialEq`. ([#79][] by [@waywardmonkeys][])
 * `ColorSpaceTag` and `HueDirection` now have bytemuck support. ([#81][] by [@waywardmonkeys][])
+* `AlphaColor`, `DynamicColor`, `OpaqueColor`, and `PremulColor` now default to an opaque white. ([#85][] by [@waywardmonkeys][])
 
 ### Changed
 
@@ -62,6 +63,7 @@ This is the initial release.
 [#79]: https://github.com/linebender/color/pull/79
 [#80]: https://github.com/linebender/color/pull/80
 [#81]: https://github.com/linebender/color/pull/81
+[#85]: https://github.com/linebender/color/pull/85
 [#86]: https://github.com/linebender/color/pull/86
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -21,6 +21,9 @@ use crate::floatfuncs::FloatFuncs;
 /// major motivation for including these is to enable weighted sums, including
 /// for spline interpolation. For cylindrical color spaces, hue fixup should
 /// be applied before interpolation.
+///
+/// The default value is an opaque white. We don't recommend relying upon this
+/// default.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[repr(transparent)]
@@ -36,6 +39,9 @@ pub struct OpaqueColor<CS> {
 /// A color with an alpha channel.
 ///
 /// A color in a color space known at compile time, with an alpha channel.
+///
+/// The default value is an opaque white. We don't recommend relying upon this
+/// default.
 ///
 /// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
 #[derive(Clone, Copy, Debug)]
@@ -59,6 +65,9 @@ pub struct AlphaColor<CS> {
 /// Following the convention of CSS Color 4, in cylindrical color spaces
 /// the hue channel is not premultiplied. If it were, interpolation would
 /// give undesirable results.
+///
+/// The default value is an opaque white. We don't recommend relying upon this
+/// default.
 ///
 /// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
 #[derive(Clone, Copy, Debug)]
@@ -634,6 +643,26 @@ impl<CS: ColorSpace> PremulColor<CS> {
             .components
             .map(|x| (x.clamp(0., 1.) * 255.0).round() as u8);
         PremulRgba8 { r, g, b, a }
+    }
+}
+
+// Defaults
+
+impl<CS: ColorSpace> Default for AlphaColor<CS> {
+    fn default() -> Self {
+        Self::WHITE
+    }
+}
+
+impl<CS: ColorSpace> Default for OpaqueColor<CS> {
+    fn default() -> Self {
+        Self::WHITE
+    }
+}
+
+impl<CS: ColorSpace> Default for PremulColor<CS> {
+    fn default() -> Self {
+        Self::WHITE
     }
 }
 

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -6,6 +6,7 @@
 use crate::{
     color::{add_alpha, fixup_hues_for_interpolate, split_alpha},
     AlphaColor, ColorSpace, ColorSpaceLayout, ColorSpaceTag, HueDirection, LinearSrgb, Missing,
+    Srgb,
 };
 use core::hash::{Hash, Hasher};
 
@@ -24,6 +25,9 @@ use core::hash::{Hash, Hasher};
 /// In other contexts, missing colors are interpreted as a zero value.
 /// When manipulating components directly, setting them nonzero when the
 /// corresponding missing flag is set may yield unexpected results.
+///
+/// The default value is an opaque white in the [sRGB](Srgb) color space with
+/// no missing components. We don't recommend relying upon this default.
 ///
 /// [Oklch]: crate::Oklch
 #[derive(Clone, Copy, Debug)]
@@ -362,6 +366,12 @@ impl DynamicColor {
             ColorSpaceLayout::HueThird => self.map(|c0, c1, h, a| [c0, c1, f(h), a]),
             _ => self.map_in(ColorSpaceTag::Oklch, |l, c, h, a| [l, c, f(h), a]),
         }
+    }
+}
+
+impl Default for DynamicColor {
+    fn default() -> Self {
+        Self::from_alpha_color(AlphaColor::<Srgb>::default())
     }
 }
 


### PR DESCRIPTION
We choose an opaque color because otherwise the `OpaqueColor` would have a substantially different default value than the other color types.

White is the same as the default color within `bevy_color`.

The default color is used by the Brush in Parley and likely other places.