### PR TITLE
Derive PartialEq by hand to avoid ColorSpace: PartialEq bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This release has an [MSRV][] of 1.82.
 * Support for the `ACEScg` colorspace. ([#54][] by [@MightyBurger][])
 * `DynamicColor` gets `with_alpha` and `multiply_alpha`. ([#71][] by [@waywardmonkeys][])
 * `DynamicColor` now impls `Hash` and `PartialEq`. ([#75][] by [@waywardmonkeys][])
-* `AlphaColor`, `OpaqueColor`, and `PremulColor` now impl `PartialEq`. ([#76][] by [@waywardmonkeys][])
+* `AlphaColor`, `OpaqueColor`, and `PremulColor` now impl `PartialEq`. ([#76][], [#86][] by [@waywardmonkeys][])
 * `HueDirection` now impls `PartialEq`. ([#79][] by [@waywardmonkeys][])
 * `ColorSpaceTag` and `HueDirection` now have bytemuck support. ([#81][] by [@waywardmonkeys][])
 
@@ -61,7 +61,8 @@ This is the initial release.
 [#78]: https://github.com/linebender/color/pull/78
 [#79]: https://github.com/linebender/color/pull/79
 [#80]: https://github.com/linebender/color/pull/80
-[#81]: https://github.com/linebender/color/pull/80
+[#81]: https://github.com/linebender/color/pull/81
+[#86]: https://github.com/linebender/color/pull/86
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -21,7 +21,7 @@ use crate::floatfuncs::FloatFuncs;
 /// major motivation for including these is to enable weighted sums, including
 /// for spline interpolation. For cylindrical color spaces, hue fixup should
 /// be applied before interpolation.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[repr(transparent)]
 pub struct OpaqueColor<CS> {
@@ -38,7 +38,7 @@ pub struct OpaqueColor<CS> {
 /// A color in a color space known at compile time, with an alpha channel.
 ///
 /// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[repr(transparent)]
 pub struct AlphaColor<CS> {
@@ -61,7 +61,7 @@ pub struct AlphaColor<CS> {
 /// give undesirable results.
 ///
 /// See [`OpaqueColor`] for a discussion of arithmetic traits and interpolation.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[repr(transparent)]
 pub struct PremulColor<CS> {
@@ -648,6 +648,26 @@ impl<CS: ColorSpace> From<OpaqueColor<CS>> for AlphaColor<CS> {
 impl<CS: ColorSpace> From<OpaqueColor<CS>> for PremulColor<CS> {
     fn from(value: OpaqueColor<CS>) -> Self {
         Self::new(add_alpha(value.components, 1.0))
+    }
+}
+
+// Partial equality - Hand derive to avoid needing ColorSpace to be PartialEq
+
+impl<CS: ColorSpace> PartialEq for AlphaColor<CS> {
+    fn eq(&self, other: &Self) -> bool {
+        self.components == other.components
+    }
+}
+
+impl<CS: ColorSpace> PartialEq for OpaqueColor<CS> {
+    fn eq(&self, other: &Self) -> bool {
+        self.components == other.components
+    }
+}
+
+impl<CS: ColorSpace> PartialEq for PremulColor<CS> {
+    fn eq(&self, other: &Self) -> bool {
+        self.components == other.components
     }
 }
 


### PR DESCRIPTION
There's no need for each `ColorSpace` to have to impl `PartialEq` since they're zero-sized types.