### PR TITLE
Treat "colour" as a typo for "color"

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -8,6 +8,7 @@
 
 # Match Identifier - Case Sensitive
 [default.extend-identifiers]
+colour = "color"
 
 # Match Inside a Word - Case Insensitive
 [default.extend-words]


### PR DESCRIPTION
We should be consistent in our spelling.