### PR TITLE
Move docs on Main Types to the top

### DIFF
--- a/color/README.md
+++ b/color/README.md
@@ -33,6 +33,20 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 Color is a Rust crate which implements color space conversions, targeting at least
 [CSS Color Level 4].
 
+## Main types
+
+The crate has two approaches to representing color in the Rust type system: a set of
+types with static color space as part of the types, and [`DynamicColor`]
+in which the color space is represented at runtime.
+
+The static color types come in three variants: [`OpaqueColor`] without an
+alpha channel, [`AlphaColor`] with a separate alpha channel, and [`PremulColor`] with
+premultiplied alpha. The last type is particularly useful for making interpolation and
+compositing more efficient. These have a marker type parameter, indicating which
+[`ColorSpace`] they are in. Conversion to another color space uses the `convert` method
+on each of these types. The static types are open-ended, as it's possible to implement
+this trait for new color spaces.
+
 ## Scope and goals
 
 Color in its entirety is an extremely deep and complex topic. It is completely impractical
@@ -71,20 +85,6 @@ maximize compatibility.
 Some of these capabilities may be added as other crates within the `color` repository,
 and we will also facilitate interoperability with other color crates in the Rust
 ecosystem as needed.
-
-## Main types
-
-The crate has two approaches to representing color in the Rust type system: a set of
-types with static color space as part of the types, and [`DynamicColor`]
-in which the color space is represented at runtime.
-
-The static color types come in three variants: [`OpaqueColor`] without an
-alpha channel, [`AlphaColor`] with a separate alpha channel, and [`PremulColor`] with
-premultiplied alpha. The last type is particularly useful for making interpolation and
-compositing more efficient. These have a marker type parameter, indicating which
-[`ColorSpace`] they are in. Conversion to another color space uses the `convert` method
-on each of these types. The static types are open-ended, as it's possible to implement
-this trait for new color spaces.
 
 ## Features
 

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -4,6 +4,20 @@
 //! Color is a Rust crate which implements color space conversions, targeting at least
 //! [CSS Color Level 4].
 //!
+//! ## Main types
+//!
+//! The crate has two approaches to representing color in the Rust type system: a set of
+//! types with static color space as part of the types, and [`DynamicColor`]
+//! in which the color space is represented at runtime.
+//!
+//! The static color types come in three variants: [`OpaqueColor`] without an
+//! alpha channel, [`AlphaColor`] with a separate alpha channel, and [`PremulColor`] with
+//! premultiplied alpha. The last type is particularly useful for making interpolation and
+//! compositing more efficient. These have a marker type parameter, indicating which
+//! [`ColorSpace`] they are in. Conversion to another color space uses the `convert` method
+//! on each of these types. The static types are open-ended, as it's possible to implement
+//! this trait for new color spaces.
+//!
 //! ## Scope and goals
 //!
 //! Color in its entirety is an extremely deep and complex topic. It is completely impractical
@@ -42,20 +56,6 @@
 //! Some of these capabilities may be added as other crates within the `color` repository,
 //! and we will also facilitate interoperability with other color crates in the Rust
 //! ecosystem as needed.
-//!
-//! ## Main types
-//!
-//! The crate has two approaches to representing color in the Rust type system: a set of
-//! types with static color space as part of the types, and [`DynamicColor`]
-//! in which the color space is represented at runtime.
-//!
-//! The static color types come in three variants: [`OpaqueColor`] without an
-//! alpha channel, [`AlphaColor`] with a separate alpha channel, and [`PremulColor`] with
-//! premultiplied alpha. The last type is particularly useful for making interpolation and
-//! compositing more efficient. These have a marker type parameter, indicating which
-//! [`ColorSpace`] they are in. Conversion to another color space uses the `convert` method
-//! on each of these types. The static types are open-ended, as it's possible to implement
-//! this trait for new color spaces.
 //!
 //! ## Features
 //!


### PR DESCRIPTION
Moves the "Main types" section above the "Scope and goals" section in the lib.rs docs.

Justification: I think the documentation on "what are the main types in this crate" / "how do I use this crate" ought to be front and center. Whereas the "background" on scope and goal is more secondary. The "Main Types" section is also quite a bit shorter than the "Scope and goals" section, so it means both fit "above the fold".

More concretely, I was reading the docs and trying to work out which type(s) could be considered the primary/default color representation(s). And it took me quite a bit of time to find it even though there was already a section explaining it.