### PR TITLE
Always return little-endian packed value in Rgba8::to_u32

### DIFF
--- a/color/src/rgba8.rs
+++ b/color/src/rgba8.rs
@@ -45,7 +45,7 @@ impl Rgba8 {
     /// most significant byte and `r` the least.
     #[must_use]
     pub const fn to_u32(self) -> u32 {
-        u32::from_le_bytes(self.to_u8_array())
+        u32::from_ne_bytes(self.to_u8_array())
     }
 }
 
@@ -94,7 +94,7 @@ impl PremulRgba8 {
     /// most significant byte and `r` the least.
     #[must_use]
     pub const fn to_u32(self) -> u32 {
-        u32::from_le_bytes(self.to_u8_array())
+        u32::from_ne_bytes(self.to_u8_array())
     }
 }
 


### PR DESCRIPTION
(And PremulRgba8.)

If the intention is for the bytes of R, G, B and A to always be in the same memory order, I believe this patch is required. The docstring on the method suggests that's the intention.

In the order of memory of `Rgba8::to_u8_array`, the red channel is at the lowest memory address and therefore (in little endian) the least significant byte. On a big endian system, using `from_le_bytes` would move the red byte to the highest memory address.