### PR TITLE
Don't enable serde's `std` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can find its changes [documented below](#020-2024-12-17).
 
 This release has an [MSRV][] of 1.82.
 
+### Changed
+
+* Don't enable `serde`'s `std` feature when enabling our `std` feature. ([#108][] by @waywardmonkeys][])
+
 ### Fixed
 
 * Make color parsing case insensitive. ([#109][] by [@raphlinus][])
@@ -78,6 +82,7 @@ This is the initial release.
 [#86]: https://github.com/linebender/color/pull/86
 [#92]: https://github.com/linebender/color/pull/92
 [#100]: https://github.com/linebender/color/pull/100
+[#108]: https://github.com/linebender/color/pull/108
 [#109]: https://github.com/linebender/color/pull/109
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.2.0...HEAD

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -17,7 +17,7 @@ targets = []
 
 [features]
 default = ["std"]
-std = ["serde?/std"]
+std = []
 libm = ["dep:libm"]
 bytemuck = ["dep:bytemuck"]
 serde = ["dep:serde"]


### PR DESCRIPTION
When we use the `serde?/std` syntax for the feature, we end up with a public dependency on `serde` even when it isn't enabled or used. It isn't compiled, but it feels wrong. We don't need the `std` feature from `serde`, so no need to enable it and someone that does will already have it enabled.