### PR TITLE
Replace `From<Rgba8>` for `PremulColor` with `From<PremulRgba8>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This release has an [MSRV][] of 1.82.
 ### Changed
 
 * Don't enable `serde`'s `std` feature when enabling our `std` feature. ([#108][] by @waywardmonkeys][])
+* `From<Rgba8>` for `PremulColor` is deprecated and replaced by `From<PremulRgba8>`. ([#113][] by @waywardmonkeys][])
 
 ### Fixed
 

--- a/color/src/rgba8.rs
+++ b/color/src/rgba8.rs
@@ -98,8 +98,15 @@ impl PremulRgba8 {
     }
 }
 
+/// This is deprecated and will be removed in 0.3.0.
 impl From<Rgba8> for PremulColor<Srgb> {
     fn from(value: Rgba8) -> Self {
+        Self::from_rgba8(value.r, value.g, value.b, value.a)
+    }
+}
+
+impl From<PremulRgba8> for PremulColor<Srgb> {
+    fn from(value: PremulRgba8) -> Self {
         Self::from_rgba8(value.r, value.g, value.b, value.a)
     }
 }


### PR DESCRIPTION
Having the `From<Rgba8>` was unintentional and should have been `From<PremulRgba8>`.

A trait impl can't be deprecated with an attribute, so just note it in the doc comment.