### PR TITLE
Serialize `XyzD65` as `xyz-d65`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can find its changes [documented below](#021-2024-12-27).
 
 This release has an [MSRV][] of 1.82.
 
+### Fixed
+
+* Colors in `XyzD65` are serialized as `xyz-d65` rather than `xyz`. ([#118][] by [@waywardmonkeys][])
+
 ## [0.2.1][] (2024-12-27)
 
 This release has an [MSRV][] of 1.82.
@@ -95,6 +99,7 @@ This is the initial release.
 [#109]: https://github.com/linebender/color/pull/109
 [#111]: https://github.com/linebender/color/pull/111
 [#113]: https://github.com/linebender/color/pull/113
+[#118]: https://github.com/linebender/color/pull/118
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.2.1...HEAD
 [0.2.1]: https://github.com/linebender/color/releases/tag/v0.2.1

--- a/color/src/serialize.rs
+++ b/color/src/serialize.rs
@@ -99,7 +99,7 @@ impl core::fmt::Display for DynamicColor {
             ColorSpaceTag::Hsl => write_legacy_function(self, "hsl", 1.0, f),
             ColorSpaceTag::Hwb => write_modern_function(self, "hwb", f),
             ColorSpaceTag::XyzD50 => write_color_function(self, "xyz-d50", f),
-            ColorSpaceTag::XyzD65 => write_color_function(self, "xyz", f),
+            ColorSpaceTag::XyzD65 => write_color_function(self, "xyz-d65", f),
             ColorSpaceTag::Lab => write_modern_function(self, "lab", f),
             ColorSpaceTag::Lch => write_modern_function(self, "lch", f),
             ColorSpaceTag::Oklab => write_modern_function(self, "oklab", f),
@@ -149,7 +149,7 @@ impl core::fmt::UpperHex for Rgba8 {
 
 #[cfg(test)]
 mod tests {
-    use crate::{parse_color, AlphaColor, DynamicColor, Hsl, Oklab, Srgb};
+    use crate::{parse_color, AlphaColor, DynamicColor, Hsl, Oklab, Srgb, XyzD65};
 
     #[test]
     fn rgb8() {
@@ -215,6 +215,12 @@ mod tests {
             (
                 DynamicColor::from_alpha_color(AlphaColor::<Oklab>::new([0.4, 0.2, -0.2, 1.])),
                 "oklab(0.4 0.2 -0.2)",
+            ),
+            (
+                DynamicColor::from_alpha_color(AlphaColor::<XyzD65>::new([
+                    0.472, 0.372, 0.131, 1.,
+                ])),
+                "color(xyz-d65 0.472 0.372 0.131)",
             ),
             // Perhaps this should actually serialize to `rgb(...)`.
             (


### PR DESCRIPTION
As noted in § 14.4 of CSS Color 4 spec, colors specified in `xyz`, which is an alias of `xyz-d65`, are in the `xyz-d65` color space.

We already only have a predefined colorspace for `XyzD65` and not just `Xyz`, but were serializing it out in the shorter form.