### PR TITLE
Specify XyzD50 and XyzD65 WHITE_COMPONENTS exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This release has an [MSRV][] of 1.82.
 
 * Support for the ACES2065-1 color space. ([#124][] by [@tomcur][])
 
+### Fixed
+
+* Specify some `ColorSpace::WHITE_COMPONENTS` to higher precision. ([#128][], [#129][] by [@tomcur][])
+
 ## [0.2.2][] (2025-01-03)
 
 This release has an [MSRV][] of 1.82.
@@ -111,6 +115,8 @@ This is the initial release.
 [#118]: https://github.com/linebender/color/pull/118
 [#119]: https://github.com/linebender/color/pull/119
 [#124]: https://github.com/linebender/color/pull/124
+[#128]: https://github.com/linebender/color/pull/128
+[#129]: https://github.com/linebender/color/pull/129
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.2.2...HEAD
 [0.2.2]: https://github.com/linebender/color/releases/tag/v0.2.2

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -679,7 +679,7 @@ impl ColorSpace for XyzD50 {
 
     const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::XyzD50);
 
-    const WHITE_COMPONENTS: [f32; 3] = [0.9642956, 1., 0.8251046];
+    const WHITE_COMPONENTS: [f32; 3] = [3457. / 3585., 1., 986. / 1195.];
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         // XYZ_to_lin_sRGB * D50_to_D65
@@ -764,7 +764,7 @@ impl ColorSpace for XyzD65 {
 
     const TAG: Option<ColorSpaceTag> = Some(ColorSpaceTag::XyzD65);
 
-    const WHITE_COMPONENTS: [f32; 3] = [0.9504559, 1., 1.0890577];
+    const WHITE_COMPONENTS: [f32; 3] = [3127. / 3290., 1., 3583. / 3290.];
 
     fn to_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         const XYZ_TO_LINEAR_SRGB: [[f32; 3]; 3] = [


### PR DESCRIPTION
This fixes two 1-ULP rounding issues (first component in `XyzD50` and last component in `XyzD65`).