### PR TITLE
First draft of Okhsv color space

### DIFF
--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -109,7 +109,7 @@ mod floatfuncs;
 pub use color::{AlphaColor, HueDirection, OpaqueColor, PremulColor};
 pub use colorspace::{
     A98Rgb, Aces2065_1, AcesCg, ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch,
-    LinearSrgb, Oklab, Oklch, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
+    LinearSrgb, Okhsv, Oklab, Oklch, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
 };
 pub use dynamic::{DynamicColor, Interpolator};
 pub use flags::{Flags, Missing};


### PR DESCRIPTION
This is a mostly mechanical translation from the [reference implementation provided by Björn Ottosson](https://github.com/bottosson/bottosson.github.io/blob/f6f08b7fde9436be1f20f66cebbc739d660898fd/misc/ok_color.h).

I've not done a deep dive into the math. This just differs by a few optimizations.

Note: the conversion into and out of this color space are approximations due to `compute_max_srgb_saturation`. The other picker, `Okhsl`, would share most of this code.