### PR TITLE
Fix `powerless_to_missing` for `Hwb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This release has an [MSRV][] of 1.82.
 ### Fixed
 
 * Correctly determine analogous components between ACES2065-1 and other color spaces when converting, to carry missing components forward. ([#144][] by [@tomcur][])
+* Fixed powerless hue component calculation for the HWB color space. ([#145][] by [@tomcur][])
 
 ## [0.2.3][] (2025-01-20)
 
@@ -142,6 +143,7 @@ This is the initial release.
 [#136]: https://github.com/linebender/color/pull/136
 [#139]: https://github.com/linebender/color/pull/139
 [#144]: https://github.com/linebender/color/pull/144
+[#145]: https://github.com/linebender/color/pull/145
 [#149]: https://github.com/linebender/color/pull/149
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.2.3...HEAD

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -290,12 +290,22 @@ impl DynamicColor {
         // and there is some controversy in discussion threads. For example,
         // in Lab-like spaces, if L is 0 do the other components become powerless?
         const POWERLESS_EPSILON: f32 = 1e-6;
-        if self.cs.layout() != ColorSpaceLayout::Rectangular
-            && self.components[1] < POWERLESS_EPSILON
-        {
-            let mut missing = self.flags.missing();
-            self.cs.set_h_missing(&mut missing, &mut self.components);
-            self.flags.set_missing(missing);
+        match self.cs {
+            ColorSpaceTag::Lch | ColorSpaceTag::Oklch | ColorSpaceTag::Hsl
+                if self.components[1] < POWERLESS_EPSILON =>
+            {
+                let mut missing = self.flags.missing();
+                self.cs.set_h_missing(&mut missing, &mut self.components);
+                self.flags.set_missing(missing);
+            }
+            ColorSpaceTag::Hwb
+                if self.components[1] + self.components[2] > 100. - 100. * POWERLESS_EPSILON =>
+            {
+                let mut missing = self.flags.missing();
+                self.cs.set_h_missing(&mut missing, &mut self.components);
+                self.flags.set_missing(missing);
+            }
+            _ => {}
         }
     }
 

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -291,13 +291,16 @@ impl DynamicColor {
         // in Lab-like spaces, if L is 0 do the other components become powerless?
         const POWERLESS_EPSILON: f32 = 1e-6;
         match self.cs {
-            ColorSpaceTag::Lch | ColorSpaceTag::Oklch | ColorSpaceTag::Hsl
+            // See CSS Color Module level 4 § 7, § 9.3, and § 9.4 (HSL, LCH, Oklch).
+            ColorSpaceTag::Hsl | ColorSpaceTag::Lch | ColorSpaceTag::Oklch
                 if self.components[1] < POWERLESS_EPSILON =>
             {
                 let mut missing = self.flags.missing();
                 self.cs.set_h_missing(&mut missing, &mut self.components);
                 self.flags.set_missing(missing);
             }
+
+            // See CSS Color Module level 4 § 8 (HWB).
             ColorSpaceTag::Hwb
                 if self.components[1] + self.components[2] > 100. - 100. * POWERLESS_EPSILON =>
             {

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -289,11 +289,16 @@ impl DynamicColor {
         // Note: the spec seems vague on the details of what this should do,
         // and there is some controversy in discussion threads. For example,
         // in Lab-like spaces, if L is 0 do the other components become powerless?
-        const POWERLESS_EPSILON: f32 = 1e-6;
+
+        /// The approximate equality range for components in (roughly) the range 0.0-1.0.
+        const POWERLESS_EPSILON_1: f32 = 1e-6;
+        /// The approximate equality range for components in (roughly) the range 0.0-100.0.
+        const POWERLESS_EPSILON_100: f32 = 100. * POWERLESS_EPSILON_1;
+
         match self.cs {
             // See CSS Color Module level 4 § 7, § 9.3, and § 9.4 (HSL, LCH, Oklch).
             ColorSpaceTag::Hsl | ColorSpaceTag::Lch | ColorSpaceTag::Oklch
-                if self.components[1] < POWERLESS_EPSILON =>
+                if self.components[1] < POWERLESS_EPSILON_1 =>
             {
                 let mut missing = self.flags.missing();
                 self.cs.set_h_missing(&mut missing, &mut self.components);
@@ -302,7 +307,7 @@ impl DynamicColor {
 
             // See CSS Color Module level 4 § 8 (HWB).
             ColorSpaceTag::Hwb
-                if self.components[1] + self.components[2] > 100. - 100. * POWERLESS_EPSILON =>
+                if self.components[1] + self.components[2] > 100. - POWERLESS_EPSILON_100 =>
             {
                 let mut missing = self.flags.missing();
                 self.cs.set_h_missing(&mut missing, &mut self.components);


### PR DESCRIPTION
Previously all non-rectangular spaces were assumed to have saturation or chroma as second component, but this is not the case for `Hwb`.

[Color Module 4](https://www.w3.org/TR/css-color-4/#valdef-hwb-hwb) states:

> If the sum white+black is greater than or equal to 100%, it defines an
> achromatic color, i.e. a shade of gray; when converted to sRGB the R, G
> and B values are identical and have the value white / (white + black).
> ...
> Achromatic HWB colors no longer contain any hint of the chosen hue. In
> this case, the hue component is powerless.