### PR TITLE
Be more `no_std`

### DIFF
--- a/color/src/cache_key.rs
+++ b/color/src/cache_key.rs
@@ -175,9 +175,9 @@ impl<T: BitEq> BitEq for &T {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
     use super::CacheKey;
     use crate::{parse_color, DynamicColor};
-
     use std::collections::HashMap;
 
     #[test]

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -1,6 +1,9 @@
 // Copyright 2024 the Color Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[cfg(feature = "std")]
+extern crate std;
+
 use core::{any::TypeId, f32};
 
 use crate::{matvecmul, tag::ColorSpaceTag, Chromaticity};
@@ -1453,10 +1456,13 @@ impl ColorSpace for Hwb {
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use crate::{
         A98Rgb, Aces2065_1, AcesCg, Chromaticity, ColorSpace, DisplayP3, Hsl, Hwb, Lab, Lch,
         LinearSrgb, Oklab, Oklch, OpaqueColor, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
     };
+    use alloc::vec::Vec;
 
     #[must_use]
     fn almost_equal<CS: ColorSpace>(col1: [f32; 3], col2: [f32; 3], absolute_epsilon: f32) -> bool {

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -82,7 +82,7 @@
 #![warn(clippy::print_stdout, clippy::print_stderr)]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![no_std]
 
 pub mod cache_key;
 mod chromaticity;

--- a/color/src/serialize.rs
+++ b/color/src/serialize.rs
@@ -150,7 +150,10 @@ impl core::fmt::UpperHex for Rgba8 {
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use crate::{parse_color, AlphaColor, DynamicColor, Hsl, Oklab, Srgb, XyzD65};
+    use alloc::format;
 
     #[test]
     fn rgb8() {


### PR DESCRIPTION
Instead of having `std` in scope and on by default, be `no_std` by default and use `std` more explicitly.