### PR TITLE
Simplify str indexing

### DIFF
--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -239,8 +239,11 @@ impl<'a> Parser<'a> {
         self.raw_ch(ch)
     }
 
+    /// Attempt to read the exact ASCII character given, returning whether that character was read.
+    ///
+    /// The parser proceeds to the next character if the character was successfully read.
     fn raw_ch(&mut self, ch: u8) -> bool {
-        debug_assert!(ch.is_ascii());
+        debug_assert!(ch.is_ascii(), "`ch` should be an ASCII character");
         if self.s.as_bytes().get(self.ix) == Some(&ch) {
             self.ix += 1;
             true

--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -240,7 +240,7 @@ impl<'a> Parser<'a> {
     }
 
     fn raw_ch(&mut self, ch: u8) -> bool {
-        if self.s[self.ix..].as_bytes().first() == Some(&ch) {
+        if self.s.as_bytes().get(self.ix) == Some(&ch) {
             self.ix += 1;
             true
         } else {

--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -243,7 +243,7 @@ impl<'a> Parser<'a> {
     ///
     /// The parser proceeds to the next character if the character was successfully read.
     fn raw_ch(&mut self, ch: u8) -> bool {
-        debug_assert!(ch.is_ascii(), "`ch` should be an ASCII character");
+        debug_assert!(ch.is_ascii(), "`ch` must be an ASCII character");
         if self.s.as_bytes().get(self.ix) == Some(&ch) {
             self.ix += 1;
             true

--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -240,6 +240,7 @@ impl<'a> Parser<'a> {
     }
 
     fn raw_ch(&mut self, ch: u8) -> bool {
+        debug_assert!(ch.is_ascii());
         if self.s.as_bytes().get(self.ix) == Some(&ch) {
             self.ix += 1;
             true


### PR DESCRIPTION
This save an unnecessary bounds check, and fixes an impending Clippy lint Bruce notified me of:

```rust
warning: calling `as_bytes` after slicing a string
   --> color/src/parse.rs:243:12
    |
243 |         if self.s[self.ix..].as_bytes().first() == Some(&ch) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&self.s.as_bytes()[self.ix..]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#sliced_string_as_bytes
    = note: `#[warn(clippy::sliced_string_as_bytes)]` on by default
```