### PR TITLE
Add `Missing::EMPTY` to allow getting a `const` empty `Missing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This release has an [MSRV][] of 1.82.
   **Note to `ColorSpace` implementers:** the `WHITE_POINT` associated constant is added to `ColorSpace`, defaulting to D65.
   Implementations with a non-D65 white point should set this constant to get correct default absolute conversion behavior.
 * Support manual chromatic adaptation of colors between arbitrary white point chromaticities.  ([#139][] by [@tomcur][])
+* Add `Missing::EMPTY` to allow getting an empty `Missing` set in `const` contexts. ([#149][] by [@tomcur][])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ This is the initial release.
 [#136]: https://github.com/linebender/color/pull/136
 [#139]: https://github.com/linebender/color/pull/139
 [#144]: https://github.com/linebender/color/pull/144
+[#149]: https://github.com/linebender/color/pull/149
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.2.3...HEAD
 [0.2.3]: https://github.com/linebender/color/releases/tag/v0.2.3

--- a/color/src/flags.rs
+++ b/color/src/flags.rs
@@ -139,6 +139,9 @@ impl core::fmt::Debug for Flags {
 }
 
 impl Missing {
+    /// The set containing no missing components.
+    pub const EMPTY: Self = Self(0);
+
     /// The set containing a single component index.
     #[inline]
     pub const fn single(ix: usize) -> Self {


### PR DESCRIPTION
The only alternative currently is `Missing::default()`, but that's not `const`.