### PR TITLE
Clamp negative percentages in HSL

### DIFF
--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -429,7 +429,7 @@ impl<'a> Parser<'a> {
         let mode = if comma { Mode::Legacy } else { Mode::Modern };
         let s = self.scaled_component(1., 1.)?.map(|x| x.max(0.));
         self.optional_comma(comma)?;
-        let l = self.scaled_component(1., 1.)?;
+        let l = self.scaled_component(1., 1.)?.map(|x| x.max(0.));
         let alpha = self.alpha(mode)?;
         self.ws();
         if !self.ch(b')') {
@@ -838,5 +838,11 @@ mod tests {
         ] {
             assert_close_color(parse_color(c1).unwrap(), parse_color(c2).unwrap());
         }
+    }
+
+    #[test]
+    fn hsl_negative_l() {
+        let mut parser = Parser::new("(800, 150%, -50%)");
+        assert_eq!(parser.hsl().unwrap().components[2], 0.0)
     }
 }

--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -843,6 +843,6 @@ mod tests {
     #[test]
     fn hsl_negative_l() {
         let mut parser = Parser::new("(800, 150%, -50%)");
-        assert_eq!(parser.hsl().unwrap().components[2], 0.0)
+        assert_eq!(parser.hsl().unwrap().components[2], 0.0);
     }
 }


### PR DESCRIPTION
From my understanding of the [spec](https://www.w3.org/TR/css-color-4/#the-hsl-notation), both, S and L need to be clamped to a valid range:

<img width="641" alt="image" src="https://github.com/user-attachments/assets/972ee6a0-ae41-457b-9d7a-639d46a6fe73" />

After making this change, we get the same result as the current conversion code in resvg (I'm attempting to integrate this crate into `svgtypes`).