### PR TITLE
Remove deprecated `From<Rgba8> for PremulColor<Srgb>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ This release has an [MSRV][] of 1.82.
 * Support manual chromatic adaptation of colors between arbitrary white point chromaticities.  ([#139][] by [@tomcur][])
 * Add `Missing::EMPTY` to allow getting an empty `Missing` set in `const` contexts. ([#149][] by [@tomcur][])
 
+### Changed
+
+* Breaking change: the deprecated conversion `From<Rgba8> for PremulColor<Srgb>` has been removed. Use `From<PremulRgba8> for PremulColor<Srgb>` instead. ([#157][] by [@tomcur][])
+
 ### Fixed
 
 * Correctly determine analogous components between ACES2065-1 and other color spaces when converting, to carry missing components forward. ([#144][] by [@tomcur][])
@@ -143,6 +147,7 @@ This is the initial release.
 [#139]: https://github.com/linebender/color/pull/139
 [#144]: https://github.com/linebender/color/pull/144
 [#149]: https://github.com/linebender/color/pull/149
+[#157]: https://github.com/linebender/color/pull/157
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.2.3...HEAD
 [0.2.3]: https://github.com/linebender/color/releases/tag/v0.2.3

--- a/color/src/rgba8.rs
+++ b/color/src/rgba8.rs
@@ -128,13 +128,6 @@ impl PremulRgba8 {
     }
 }
 
-/// This is deprecated and will be removed in 0.3.0.
-impl From<Rgba8> for PremulColor<Srgb> {
-    fn from(value: Rgba8) -> Self {
-        Self::from_rgba8(value.r, value.g, value.b, value.a)
-    }
-}
-
 impl From<PremulRgba8> for PremulColor<Srgb> {
     fn from(value: PremulRgba8) -> Self {
         Self::from_rgba8(value.r, value.g, value.b, value.a)


### PR DESCRIPTION
Users should use `From<PremulRgba8> for PremulColor<Srgb>` instead.

Resolves https://github.com/linebender/color/issues/134.