### PR TITLE
Faster rounding in `{AlphaColor,OpaqueColor,PremulColor}::to_rgba8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This release has an [MSRV][] of 1.82.
 
 * Breaking change: the deprecated conversion `From<Rgba8> for PremulColor<Srgb>` has been removed. Use `From<PremulRgba8> for PremulColor<Srgb>` instead. ([#157][] by [@tomcur][])
 * Improve `no_std` support. ([#146][] by [@waywardmonkeys][])
+* Make `{AlphaColor, OpaqueColor, PremulColor}::to_rgba8` faster. ([#166][] by [@tomcur][])
 
 ### Fixed
 
@@ -163,6 +164,7 @@ This is the initial release.
 [#159]: https://github.com/linebender/color/pull/159
 [#164]: https://github.com/linebender/color/pull/164
 [#165]: https://github.com/linebender/color/pull/165
+[#166]: https://github.com/linebender/color/pull/166
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.2.3...HEAD
 [0.2.3]: https://github.com/linebender/color/releases/tag/v0.2.3

--- a/color/.clippy.toml
+++ b/color/.clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = ["ACEScg", "ACEScc", "ACEScct", "ProPhoto", ".."]
+doc-valid-idents = ["AArch64", "ACEScg", "ACEScc", "ACEScct", "ProPhoto", ".."]

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -1029,7 +1029,7 @@ mod tests {
             v.round() as u8
         }
 
-        // Check the rounding behavior of als floating point values within (and near) the range
+        // Check the rounding behavior of all floating point values within (and near) the range
         // 0-255.
         let mut failures = alloc::vec![];
         let mut v = -1_f32;

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -1019,4 +1019,28 @@ mod tests {
 
         assert_eq!(&failures, &[0.49999997]);
     }
+
+    /// If you don't trust the test above, run this one by removing `#[ignore]`.
+    #[test]
+    #[ignore]
+    fn fast_round_full() {
+        #[expect(clippy::cast_possible_truncation, reason = "deliberate quantization")]
+        fn real_round_to_u8(v: f32) -> u8 {
+            v.round() as u8
+        }
+
+        // Check the rounding behavior at integer and half integer values within (and near) the
+        // range 0-255, as well as one ULP up and down from those values.
+        let mut failures = alloc::vec![];
+        let mut v = -1_f32;
+
+        while v <= 256. {
+            if real_round_to_u8(v) != fast_round_to_u8(v) {
+                failures.push(v);
+            }
+            v = v.next_up();
+        }
+
+        assert_eq!(&failures, &[0.49999997]);
+    }
 }

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -1029,8 +1029,8 @@ mod tests {
             v.round() as u8
         }
 
-        // Check the rounding behavior at integer and half integer values within (and near) the
-        // range 0-255, as well as one ULP up and down from those values.
+        // Check the rounding behavior of als floating point values within (and near) the range
+        // 0-255.
         let mut failures = alloc::vec![];
         let mut v = -1_f32;
 

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -1019,9 +1019,10 @@ mod tests {
         assert_eq!(&failures, &[0.49999997]);
     }
 
-    /// A more thorough test than the one above that tests only the values which are likely to fail.
-    /// This test runs through approximately 200 million floats, so can be somewhat slow (seconds
-    /// rather than milliseconds). To run this test, use the `--ignored` flag.
+    /// A more thorough test than the one above: the one above only tests values that are likely to
+    /// fail. This test runs through all floats in and near the range of interest (approximately
+    /// 200 million floats), so can be somewhat slow (seconds rather than milliseconds). To run
+    /// this test, use the `--ignored` flag.
     #[test]
     #[ignore = "Takes too long to execute."]
     fn fast_round_full() {

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -1019,7 +1019,9 @@ mod tests {
         assert_eq!(&failures, &[0.49999997]);
     }
 
-    /// If you don't trust the test above, run this one by removing `#[ignore]`.
+    /// A more thorough test than the one above that tests only the values which are likely to fail.
+    /// This test runs through approximately 200 million floats, so can be somewhat slow (seconds 
+    /// rather than milliseconds). To run this test, use the `--ignored` flag.
     #[test]
     #[ignore = "Takes too long to execute."]
     fn fast_round_full() {

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -1003,7 +1003,7 @@ mod tests {
 
             let mut validate_rounding = |val: f32| {
                 if real_round_to_u8(val) != fast_round_to_u8(val) {
-                    failures.push(val)
+                    failures.push(val);
                 }
             };
 

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -1001,18 +1001,17 @@ mod tests {
             // and half integers are exactly representable in this range.
             assert!(v.abs().fract() == 0. || v.abs().fract() == 0.5, "{v}");
 
-            let down = v.next_down();
-            let up = v.next_up();
+            let mut validate_rounding = |val: f32| {
+                if real_round_to_u8(val) != fast_round_to_u8(val) {
+                    failures.push(val)
+                }
+            };
 
-            if real_round_to_u8(down) != fast_round_to_u8(down) {
-                failures.push(down);
-            }
-            if real_round_to_u8(v) != fast_round_to_u8(v) {
-                failures.push(v);
-            }
-            if real_round_to_u8(up) != fast_round_to_u8(up) {
-                failures.push(up);
-            }
+            validate_rounding(v.next_down().next_down());
+            validate_rounding(v.next_down());
+            validate_rounding(v);
+            validate_rounding(v.next_up());
+            validate_rounding(v.next_up().next_up());
 
             v += 0.5;
         }
@@ -1022,7 +1021,7 @@ mod tests {
 
     /// If you don't trust the test above, run this one by removing `#[ignore]`.
     #[test]
-    #[ignore]
+    #[ignore = "Takes too long to execute."]
     fn fast_round_full() {
         #[expect(clippy::cast_possible_truncation, reason = "deliberate quantization")]
         fn real_round_to_u8(v: f32) -> u8 {

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -1020,7 +1020,7 @@ mod tests {
     }
 
     /// A more thorough test than the one above that tests only the values which are likely to fail.
-    /// This test runs through approximately 200 million floats, so can be somewhat slow (seconds 
+    /// This test runs through approximately 200 million floats, so can be somewhat slow (seconds
     /// rather than milliseconds). To run this test, use the `--ignored` flag.
     #[test]
     #[ignore = "Takes too long to execute."]

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -668,7 +668,7 @@ impl<CS: ColorSpace> PremulColor<CS> {
 
 /// Fast rounding of `f32` to integer `u8`, rounding ties up.
 ///
-/// Targetting x86, `f32::round` calls out to libc `roundf`. Even if that call were inlined, it is
+/// Targeting x86, `f32::round` calls out to libc `roundf`. Even if that call were inlined, it is
 /// branchy, which would make it relatively slow. The following is faster, and on the range `0-255`
 /// almost correct*. AArch64 has dedicated rounding instructions so does not need this
 /// optimization, but the following is still fast.


### PR DESCRIPTION
Resolves #142. See also the discussion at https://github.com/linebender/vello/pull/830#discussion_r1982017666.

On x86, `f32::round` is slow as it calls out to the IEEE754-adhering libc function `roundf`. See, e.g., the branchy [glibc `roundf`](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/ieee754/flt-32/s_roundf.c;h=eb714e975e48f737c140a1dd666135759ac0ffe3;hb=HEAD) and [musl `roundf`](https://git.etalabs.net/cgit/musl/tree/src/math/roundf.c?h=c47ad25ea3b484e10326f933e927c0bc8cded3da) implementations. On AArch64, the compiler can make use of hardware instructions instead.

The knowledge that the output range is `0-255`, allows writing an almost-correct rounding implementation that doesn't require calling out to libc or branching. This is fast on both x86 and AArch64.

Codegen:
x86: https://godbolt.org/z/PaEP43fGP
AArch64: https://godbolt.org/z/vd9Wcjz6q