### PR TITLE
Reuse XYZ-D65's conversions for XYZ-D50 absolute conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can find its changes [documented below](#030-2025-04-30).
 
 This release has an [MSRV][] of 1.82.
 
+### Added
+
+* Implement absolute color conversion methods for XYZ-D50 for faster conversion without chromatic adaptation to and from this color space. ([#170][] by [@tomcur][])
+
 ## [0.3.0][] (2025-04-30)
 
 This release has an [MSRV][] of 1.82.
@@ -170,6 +174,7 @@ This is the initial release.
 [#164]: https://github.com/linebender/color/pull/164
 [#165]: https://github.com/linebender/color/pull/165
 [#166]: https://github.com/linebender/color/pull/166
+[#170]: https://github.com/linebender/color/pull/170
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/color/releases/tag/v0.3.0

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -1061,6 +1061,19 @@ impl ColorSpace for XyzD50 {
         matvecmul(&LINEAR_SRGB_TO_XYZ, src)
     }
 
+    fn to_linear_srgb_absolute(src: [f32; 3]) -> [f32; 3] {
+        // Reuse XYZ-D65's conversions. This works because XYZ-D65 and sRGB both use the D65 white
+        // point, so the "relative" conversion specified in XYZ-D65 to/from linear sRGB is an
+        // absolute one. Plus, though XYZ-D50 is relative to D50, XYZ-D50 and XYZ-D65 are otherwise
+        // the same color space.
+        XyzD65::to_linear_srgb(src)
+    }
+
+    fn from_linear_srgb_absolute(src: [f32; 3]) -> [f32; 3] {
+        // See the note in the method above.
+        XyzD65::from_linear_srgb(src)
+    }
+
     fn clip([x, y, z]: [f32; 3]) -> [f32; 3] {
         [x, y, z]
     }


### PR DESCRIPTION
More specifically: for the absolute conversions to/from linear sRGB.

This works because XYZ-D65 and sRGB both use the D65 white point, so the "relative" conversion specified in XYZ-D65 to/from linear sRGB is an absolute one. Plus, though XYZ-D50 is relative to D50, XYZ-D50 and XYZ-D65 are otherwise the same color space.