### PR TITLE
Fix `core_float_math` nightly compilation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can find its changes [documented below](#030-2025-04-30).
 
 This release has an [MSRV][] of 1.82.
 
+### Fixed
+
+* Compilation failure with nightly Rust due to `core_float_math` changes. ([#175][] by [@ajakubowicz-canva][])
+
 ## [0.3.0][] (2025-04-30)
 
 This release has an [MSRV][] of 1.82.
@@ -118,6 +122,7 @@ This release has an [MSRV][] of 1.82.
 
 This is the initial release.
 
+[@ajakubowicz-canva]: https://github.com/ajakubowicz-canva
 [@DJMcNab]: https://github.com/DJMcNab
 [@LaurenzV]: https://github.com/LaurenzV
 [@MightyBurger]: https://github.com/MightyBurger
@@ -170,6 +175,7 @@ This is the initial release.
 [#164]: https://github.com/linebender/color/pull/164
 [#165]: https://github.com/linebender/color/pull/165
 [#166]: https://github.com/linebender/color/pull/166
+[#175]: https://github.com/linebender/color/pull/175
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/linebender/color/releases/tag/v0.3.0

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -16,7 +16,7 @@ use crate::floatfuncs::FloatFuncs;
 /// Use `F32::cbrt` to call a method on the `f32` type, rather than accessing a function from
 /// `core::f32` with the same name. Currently `core::f32` implements unstable `core_float_math`
 /// features that break CI.
-/// Issue: https://github.com/rust-lang/rust/issues/137578
+/// Issue: <https://github.com/rust-lang/rust/issues/137578>
 type F32 = f32;
 
 /// The main trait for color spaces.

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -13,7 +13,7 @@ use crate::floatfuncs::FloatFuncs;
 
 /// Type alias to disambiguate between the `f32` primitive type and `core::f32` module.
 ///
-/// Use `F32::cbrt` to call a method on the `f32`` type, rather than accessing a function from
+/// Use `F32::cbrt` to call a method on the `f32` type, rather than accessing a function from
 /// `core::f32` with the same name. Currently `core::f32` implements unstable `core_float_math`
 /// features that break CI.
 /// Issue: https://github.com/rust-lang/rust/issues/137578

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -11,6 +11,14 @@ use crate::{matvecmul, tag::ColorSpaceTag, Chromaticity};
 #[cfg(all(not(feature = "std"), not(test)))]
 use crate::floatfuncs::FloatFuncs;
 
+/// Type alias to disambiguate between the `f32` primitive type and `core::f32` module.
+///
+/// Use `F32::cbrt` to call a method on the `f32`` type, rather than accessing a function from
+/// `core::f32` with the same name. Currently `core::f32` implements unstable `core_float_math`
+/// features that break CI.
+/// Issue: https://github.com/rust-lang/rust/issues/137578
+type F32 = f32;
+
 /// The main trait for color spaces.
 ///
 /// This can be implemented by clients for conversions in and out of
@@ -337,7 +345,7 @@ impl ColorSpace for LinearSrgb {
     }
 
     fn scale_chroma(src: [f32; 3], scale: f32) -> [f32; 3] {
-        let lms = matvecmul(&OKLAB_SRGB_TO_LMS, src).map(f32::cbrt);
+        let lms = matvecmul(&OKLAB_SRGB_TO_LMS, src).map(F32::cbrt);
         let l = OKLAB_LMS_TO_LAB[0];
         let lightness = l[0] * lms[0] + l[1] * lms[1] + l[2] * lms[2];
         let lms_scaled = [
@@ -1221,7 +1229,7 @@ impl ColorSpace for Oklab {
     }
 
     fn from_linear_srgb(src: [f32; 3]) -> [f32; 3] {
-        let lms = matvecmul(&OKLAB_SRGB_TO_LMS, src).map(f32::cbrt);
+        let lms = matvecmul(&OKLAB_SRGB_TO_LMS, src).map(F32::cbrt);
         matvecmul(&OKLAB_LMS_TO_LAB, lms)
     }
 

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -4,20 +4,12 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-use core::{any::TypeId, f32};
+use core::{any::TypeId, f32::consts::PI};
 
 use crate::{matvecmul, tag::ColorSpaceTag, Chromaticity};
 
 #[cfg(all(not(feature = "std"), not(test)))]
 use crate::floatfuncs::FloatFuncs;
-
-/// Type alias to disambiguate between the `f32` primitive type and `core::f32` module.
-///
-/// Use `F32::cbrt` to call a method on the `f32` type, rather than accessing a function from
-/// `core::f32` with the same name. Currently `core::f32` implements unstable `core_float_math`
-/// features that break CI.
-/// Issue: <https://github.com/rust-lang/rust/issues/137578>
-type F32 = f32;
 
 /// The main trait for color spaces.
 ///
@@ -345,7 +337,7 @@ impl ColorSpace for LinearSrgb {
     }
 
     fn scale_chroma(src: [f32; 3], scale: f32) -> [f32; 3] {
-        let lms = matvecmul(&OKLAB_SRGB_TO_LMS, src).map(F32::cbrt);
+        let lms = matvecmul(&OKLAB_SRGB_TO_LMS, src).map(f32::cbrt);
         let l = OKLAB_LMS_TO_LAB[0];
         let lightness = l[0] * lms[0] + l[1] * lms[1] + l[2] * lms[2];
         let lms_scaled = [
@@ -1229,7 +1221,7 @@ impl ColorSpace for Oklab {
     }
 
     fn from_linear_srgb(src: [f32; 3]) -> [f32; 3] {
-        let lms = matvecmul(&OKLAB_SRGB_TO_LMS, src).map(F32::cbrt);
+        let lms = matvecmul(&OKLAB_SRGB_TO_LMS, src).map(f32::cbrt);
         matvecmul(&OKLAB_LMS_TO_LAB, lms)
     }
 
@@ -1261,7 +1253,7 @@ impl From<Oklab> for ColorSpaceTag {
 
 /// Rectangular to cylindrical conversion.
 fn lab_to_lch([l, a, b]: [f32; 3]) -> [f32; 3] {
-    let mut h = b.atan2(a) * (180. / f32::consts::PI);
+    let mut h = b.atan2(a) * (180. / PI);
     if h < 0.0 {
         h += 360.0;
     }
@@ -1271,7 +1263,7 @@ fn lab_to_lch([l, a, b]: [f32; 3]) -> [f32; 3] {
 
 /// Cylindrical to rectangular conversion.
 fn lch_to_lab([l, c, h]: [f32; 3]) -> [f32; 3] {
-    let (sin, cos) = (h * (f32::consts::PI / 180.)).sin_cos();
+    let (sin, cos) = (h * (PI / 180.)).sin_cos();
     let a = c * cos;
     let b = c * sin;
     [l, a, b]


### PR DESCRIPTION
### Context

This PR fixes an error in CI when using nightly toolchain:

```
error[E0658]: use of unstable library feature `core_float_math`
```

This error can be seen in `vello` here:
  - E.g. https://github.com/linebender/vello/actions/runs/15104337336/job/42450338042

### Fix

Fix was entirely proposed by @DJMcNab here: [#vello > cargo doc CI failing with rust nightly @ 💬](https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/cargo.20doc.20CI.20failing.20with.20rust.20nightly/near/519001092)

### Test plan

CI