### PR TITLE
Prepare to release 0.3.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published Color release is [0.3.0](#030-2025-04-30) which was released on 2025-04-30.
-You can find its changes [documented below](#030-2025-04-30).
+The latest published Color release is [0.3.1](#031-2025-05-19) which was released on 2025-05-19.
+You can find its changes [documented below](#031-2025-05-19).
 
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.82.
+
+## [0.3.1][] (2025-05-19)
 
 This release has an [MSRV][] of 1.82.
 
@@ -177,7 +181,8 @@ This is the initial release.
 [#166]: https://github.com/linebender/color/pull/166
 [#175]: https://github.com/linebender/color/pull/175
 
-[Unreleased]: https://github.com/linebender/color/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/linebender/color/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/linebender/color/releases/tag/v0.3.1
 [0.3.0]: https://github.com/linebender/color/releases/tag/v0.3.0
 [0.2.3]: https://github.com/linebender/color/releases/tag/v0.2.3
 [0.2.2]: https://github.com/linebender/color/releases/tag/v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "color"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytemuck",
  "libm",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "color_operations"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "color",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["color", "color_operations"]
 #
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the `workspace.dependencies` section in this file.
-version = "0.3.0"
+version = "0.3.1"
 
 edition = "2021"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
@@ -20,8 +20,8 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/color"
 
 [workspace.dependencies]
-color = { version = "0.3.0", path = "color", default-features = false }
-color_operations = { version = "0.3.0", path = "color_operations" }
+color = { version = "0.3.1", path = "color", default-features = false }
+color_operations = { version = "0.3.1", path = "color_operations" }
 
 [workspace.lints]
 rust.unsafe_code = "deny"


### PR DESCRIPTION
Anyone depending on `color` can't currently build with nightly, so let's get this release out ASAP.