### PR TITLE
 Support interpolating in straight alpha space by accepting `AlphaInterpolationSpace` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can find its changes [documented below](#031-2025-05-19).
 
 This release has an [MSRV][] of 1.82.
 
+### Added
+
+* Support interpolating in straight alpha space by accepting `AlphaInterpolationSpace` argument. ([#185][] by [@sagudev][])
+
 ## [0.3.1][] (2025-05-19)
 
 This release has an [MSRV][] of 1.82.
@@ -139,6 +143,7 @@ This is the initial release.
 [@LaurenzV]: https://github.com/LaurenzV
 [@MightyBurger]: https://github.com/MightyBurger
 [@raphlinus]: https://github.com/raphlinus
+[@sagudev]: https://github.com/sagudev
 [@tomcur]: https://github.com/tomcur
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 
@@ -188,6 +193,7 @@ This is the initial release.
 [#165]: https://github.com/linebender/color/pull/165
 [#166]: https://github.com/linebender/color/pull/166
 [#175]: https://github.com/linebender/color/pull/175
+[#185]: https://github.com/linebender/color/pull/185
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.3.1...HEAD
 [0.3.1]: https://github.com/linebender/color/releases/tag/v0.3.1

--- a/color/examples/gradient.rs
+++ b/color/examples/gradient.rs
@@ -11,7 +11,10 @@
 //! cargo run --example gradient 'oklab(0.5 0.2 0)' 'rgb(0, 200, 0, 0.8)' oklab
 //! ```
 
-use color::{gradient, ColorSpaceTag, DynamicColor, GradientIter, HueDirection, Srgb};
+use color::{
+    gradient, AlphaInterpolationSpace, ColorSpaceTag, DynamicColor, GradientIter, HueDirection,
+    Srgb,
+};
 
 fn main() {
     let mut args = std::env::args().skip(1);
@@ -22,7 +25,14 @@ fn main() {
     let cs_s_raw = args.next();
     let cs_s = cs_s_raw.as_deref().unwrap_or("srgb");
     let cs: ColorSpaceTag = cs_s.parse().expect("error parsing color space");
-    let gradient: GradientIter<Srgb> = gradient(c1, c2, cs, HueDirection::default(), 0.02);
+    let gradient: GradientIter<Srgb> = gradient(
+        c1,
+        c2,
+        cs,
+        HueDirection::default(),
+        0.02,
+        AlphaInterpolationSpace::Premultiplied,
+    );
     println!("<!DOCTYPE html>");
     println!("<html>");
     println!("<head>");
@@ -31,11 +41,7 @@ fn main() {
     println!("#basic {{ background: linear-gradient(to right in {cs_s}, {c1_s}, {c2_s}) }}");
     print!("#ours {{ background: linear-gradient(to right");
     for (t, stop) in gradient {
-        print!(
-            ", {} {}%",
-            DynamicColor::from_alpha_color(stop.un_premultiply()),
-            t * 100.0
-        );
+        print!(", {} {}%", DynamicColor::from_alpha_color(stop), t * 100.0);
     }
     println!(") }}");
     println!("</style>");

--- a/color/examples/interp.rs
+++ b/color/examples/interp.rs
@@ -11,7 +11,7 @@
 //! cargo run --example interp 'oklab(0.5 0.2 0)' 'rgb(0, 200, 0, 0.8)' oklab
 //! ```
 
-use color::{ColorSpaceTag, HueDirection};
+use color::{AlphaInterpolationSpace, ColorSpaceTag, HueDirection};
 
 fn main() {
     let mut args = std::env::args().skip(1);
@@ -30,7 +30,12 @@ fn main() {
     println!("div.g {{ height: 100px }}");
     let pct = 100.0 / N as f64;
     println!("span {{ width: {pct}%; display: inline-block; height: 100px; margin: 0 }}");
-    let interpolator = c1.interpolate(c2, cs, HueDirection::default());
+    let interpolator = c1.interpolate(
+        c2,
+        cs,
+        HueDirection::default(),
+        AlphaInterpolationSpace::Premultiplied,
+    );
     for i in 0..=N {
         let t = i as f32 / (N as f32);
         let c = interpolator.eval(t);

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -108,7 +108,7 @@ mod impl_bytemuck;
 mod floatfuncs;
 
 pub use chromaticity::Chromaticity;
-pub use color::{AlphaColor, HueDirection, OpaqueColor, PremulColor};
+pub use color::{AlphaColor, AlphaInterpolationSpace, HueDirection, OpaqueColor, PremulColor};
 pub use colorspace::{
     A98Rgb, Aces2065_1, AcesCg, ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch,
     LinearSrgb, Oklab, Oklch, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,


### PR DESCRIPTION
Implementation is pretty simple, we premul step into before interpolation and only do it if actually needed (`AlphaInterpolationSpace::Premultiplied`). I also added unpremultiplied test.

I used dynamic (or alpha) color everywhere as even [CSS that does interpolation in premultiplied alpha converts it back to unpremultiplied](https://www.w3.org/TR/css-color-4/#interpolation):

> changing the color components to [premultiplied](https://www.w3.org/TR/css-color-4/#premultiplied) form
> linearly interpolating each component of the computed value of the color separately
> undoing [premultiplication](https://www.w3.org/TR/css-color-4/#premultiplied)

Fixes #184

This is breaking change.