### PR TITLE
to_degrees + to_radians instead of manual conversion

### DIFF
--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-use core::{any::TypeId, f32::consts::PI};
+use core::any::TypeId;
 
 use crate::{matvecmul, tag::ColorSpaceTag, Chromaticity};
 


### PR DESCRIPTION
More readable, and should Rust `core` ever choose a faster/more precise algorithm it will be available right away.