### PR TITLE
Support interpolating in unpremultiplied (straight) alpha space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This release has an [MSRV][] of 1.82.
 
 ### Added
 
-* Support interpolating in unpremultiplied (straight) alpha space.
+* Add `interpolate_unpremultiplied` and `gradient_unpremultiplied` for interpolating in unpremultiplied (straight) alpha space.
   This allows using Color to implement web rendering features which specify such gradient rendering. ([#185][] by [@sagudev][])
 
 ## [0.3.1][] (2025-05-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ You can find its changes [documented below](#031-2025-05-19).
 
 This release has an [MSRV][] of 1.82.
 
+### Added
+
+* Support interpolating in unpremultiplied (straight) alpha space.
+  This allows using Color to implement web rendering features which specify such gradient rendering. ([#185][] by [@sagudev][])
+
 ## [0.3.1][] (2025-05-19)
 
 This release has an [MSRV][] of 1.82.
@@ -139,6 +144,7 @@ This is the initial release.
 [@LaurenzV]: https://github.com/LaurenzV
 [@MightyBurger]: https://github.com/MightyBurger
 [@raphlinus]: https://github.com/raphlinus
+[@sagudev]: https://github.com/sagudev
 [@tomcur]: https://github.com/tomcur
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 
@@ -188,6 +194,7 @@ This is the initial release.
 [#165]: https://github.com/linebender/color/pull/165
 [#166]: https://github.com/linebender/color/pull/166
 [#175]: https://github.com/linebender/color/pull/175
+[#185]: https://github.com/linebender/color/pull/185
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.3.1...HEAD
 [0.3.1]: https://github.com/linebender/color/releases/tag/v0.3.1

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -110,8 +110,6 @@ pub enum HueDirection {
 /// Defines how color channels should be handled when interpolating
 /// between transparent colors.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[repr(u8)]
 pub(crate) enum InterpolationAlphaSpace {
     /// Colors are interpolated with their color channels premultiplied by the alpha
     /// channel. This is almost always what you want.

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -112,11 +112,7 @@ pub enum HueDirection {
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
-#[expect(
-    clippy::exhaustive_enums,
-    reason = "There are only two ways to do interpolation."
-)]
-pub enum InterpolationAlphaSpace {
+pub(crate) enum InterpolationAlphaSpace {
     /// Colors are interpolated with their color channels premultiplied by the alpha
     /// channel. This is almost always what you want.
     ///
@@ -146,13 +142,8 @@ pub enum InterpolationAlphaSpace {
 }
 
 impl InterpolationAlphaSpace {
-    /// Returns `true` if the alpha mode is [`InterpolationAlphaSpace::Premultiplied`].
-    pub const fn is_premultiplied(&self) -> bool {
-        matches!(self, Self::Premultiplied)
-    }
-
     /// Returns `true` if the alpha mode is [`InterpolationAlphaSpace::Unpremultiplied`].
-    pub const fn is_unpremultiplied(&self) -> bool {
+    pub(crate) const fn is_unpremultiplied(self) -> bool {
         matches!(self, Self::Unpremultiplied)
     }
 }

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -455,7 +455,7 @@ impl<CS: ColorSpace> AlphaColor<CS> {
 
     /// Difference between two colors by Euclidean metric.
     #[must_use]
-    pub fn difference(self, other: Self) -> f32 {
+    pub(crate) fn difference(self, other: Self) -> f32 {
         let d = (self - other).components;
         (d[0] * d[0] + d[1] * d[1] + d[2] * d[2] + d[3] * d[3]).sqrt()
     }

--- a/color/src/color.rs
+++ b/color/src/color.rs
@@ -107,6 +107,56 @@ pub enum HueDirection {
     // NOTICE: If a new value is added, be sure to modify `MAX_VALUE` in the bytemuck impl.
 }
 
+/// Defines how color channels should be handled when interpolating
+/// between transparent colors.
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(u8)]
+#[expect(
+    clippy::exhaustive_enums,
+    reason = "There are only two ways to do interpolation."
+)]
+pub enum InterpolationAlphaSpace {
+    /// Colors are interpolated with their color channels premultiplied by the alpha
+    /// channel. This is almost always what you want.
+    ///
+    /// Used when interpolating colors in the premultiplied alpha space, which allows
+    /// for correct interpolation when colors are transparent. This matches behavior
+    /// described in [CSS Color Module Level 4 § 12.3].
+    ///
+    /// Following the convention of CSS Color Module Level 4, in cylindrical color
+    /// spaces the hue channel is not premultiplied. If it were, interpolation would
+    /// give undesirable results. See also [`PremulColor`].
+    ///
+    /// [CSS Color Module Level 4 § 12.3]: https://drafts.csswg.org/css-color/#interpolation-alpha
+    #[default]
+    Premultiplied = 0,
+    /// Colors are interpolated without premultiplying their color channels by the alpha channel.
+    ///
+    /// This causes color information to leak out of transparent colors. For example, when
+    /// interpolating from a fully transparent red to a fully opaque blue in sRGB, this
+    /// method will go through an intermediate purple.
+    ///
+    /// Used when interpolating colors in the unpremultiplied (straight) alpha space.
+    /// This matches behavior of gradients in the HTML `canvas` element.
+    /// See [The 2D rendering context § Fill and stroke styles].
+    ///
+    /// [The 2D rendering context § Fill and stroke styles]: https://html.spec.whatwg.org/multipage/#interpolation
+    Unpremultiplied = 1,
+}
+
+impl InterpolationAlphaSpace {
+    /// Returns `true` if the alpha mode is [`InterpolationAlphaSpace::Premultiplied`].
+    pub const fn is_premultiplied(&self) -> bool {
+        matches!(self, Self::Premultiplied)
+    }
+
+    /// Returns `true` if the alpha mode is [`InterpolationAlphaSpace::Unpremultiplied`].
+    pub const fn is_unpremultiplied(&self) -> bool {
+        matches!(self, Self::Unpremultiplied)
+    }
+}
+
 /// Fixup hue based on specified hue direction.
 ///
 /// Reference: §12.4 of CSS Color 4 spec
@@ -410,6 +460,13 @@ impl<CS: ColorSpace> AlphaColor<CS> {
     pub const fn premultiply(self) -> PremulColor<CS> {
         let (opaque, alpha) = split_alpha(self.components);
         PremulColor::new(add_alpha(CS::LAYOUT.scale(opaque, alpha), alpha))
+    }
+
+    /// Difference between two colors by Euclidean metric.
+    #[must_use]
+    pub fn difference(self, other: Self) -> f32 {
+        let d = (self - other).components;
+        (d[0] * d[0] + d[1] * d[1] + d[2] * d[2] + d[3] * d[3]).sqrt()
     }
 
     /// Linearly interpolate colors, without hue fixup.

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -356,20 +356,20 @@ impl DynamicColor {
     }
 
     /// Interpolate two colors.
-/// Interpolate two colors without alpha premultiplication.
-///
-/// Similar to [`interpolate`], but colors are interpolated without premultiplying their color
-/// channels by the alpha channel. This is almost never what you want.
-///
-/// This causes color information to leak out of transparent colors. For example, when
-/// interpolating from a fully transparent red to a fully opaque blue in sRGB, this
-/// method will go through an intermediate purple.
-///
-/// This matches behavior of gradients in the HTML `canvas` element.
-/// See [The 2D rendering context § Fill and stroke styles][HTML 2D Canvas] of the
-/// HTML 2D Canvas specification.
-///
-/// [HTML 2D Canvas]: https://html.spec.whatwg.org/multipage/#interpolation
+    /// Interpolate two colors without alpha premultiplication.
+    ///
+    /// Similar to [`interpolate`], but colors are interpolated without premultiplying their color
+    /// channels by the alpha channel. This is almost never what you want.
+    ///
+    /// This causes color information to leak out of transparent colors. For example, when
+    /// interpolating from a fully transparent red to a fully opaque blue in sRGB, this
+    /// method will go through an intermediate purple.
+    ///
+    /// This matches behavior of gradients in the HTML `canvas` element.
+    /// See [The 2D rendering context § Fill and stroke styles][HTML 2D Canvas] of the
+    /// HTML 2D Canvas specification.
+    ///
+    /// [HTML 2D Canvas]: https://html.spec.whatwg.org/multipage/#interpolation
     /// The colors are interpolated linearly from `self` to `other` in the color space given by
     /// `cs`. When interpolating in a cylindrical color space, the hue can be interpolated in
     /// multiple ways. The [`direction`](`HueDirection`) parameter controls the way in which the

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -7,7 +7,7 @@ use crate::{
     cache_key::{BitEq, BitHash},
     color::{add_alpha, fixup_hues_for_interpolate, split_alpha},
     AlphaColor, Chromaticity, ColorSpace, ColorSpaceLayout, ColorSpaceTag, Flags, HueDirection,
-    LinearSrgb, Missing,
+    InterpolationAlphaSpace, LinearSrgb, Missing,
 };
 use core::hash::{Hash, Hasher};
 
@@ -54,12 +54,13 @@ pub struct DynamicColor {
     reason = "it's an intermediate struct, only used for eval"
 )]
 pub struct Interpolator {
-    premul1: [f32; 3],
+    color1: [f32; 3],
     alpha1: f32,
-    delta_premul: [f32; 3],
+    delta_color: [f32; 3],
     delta_alpha: f32,
     cs: ColorSpaceTag,
     missing: Missing,
+    interpolation_alpha_space: InterpolationAlphaSpace,
 }
 
 impl DynamicColor {
@@ -274,15 +275,18 @@ impl DynamicColor {
         }
     }
 
-    fn premultiply_split(self) -> ([f32; 3], f32) {
+    pub(crate) fn split(self, alpha_type: InterpolationAlphaSpace) -> ([f32; 3], f32) {
         // Reference: §12.3 of Color 4 spec
         let (opaque, alpha) = split_alpha(self.components);
-        let premul = if alpha == 1.0 || self.flags.missing().contains(3) {
+        let color = if alpha == 1.0
+            || self.flags.missing().contains(3)
+            || alpha_type.is_unpremultiplied()
+        {
             opaque
         } else {
             self.cs.layout().scale(opaque, alpha)
         };
-        (premul, alpha)
+        (color, alpha)
     }
 
     fn powerless_to_missing(&mut self) {
@@ -348,6 +352,43 @@ impl DynamicColor {
         cs: ColorSpaceTag,
         direction: HueDirection,
     ) -> Interpolator {
+        self.interpolate_with_alpha(other, cs, direction, InterpolationAlphaSpace::Premultiplied)
+    }
+
+    /// Interpolate two colors.
+    ///
+    /// The colors are interpolated linearly from `self` to `other` in the color space given by
+    /// `cs`. When interpolating in a cylindrical color space, the hue can be interpolated in
+    /// multiple ways. The [`direction`](`HueDirection`) parameter controls the way in which the
+    /// hue is interpolated.
+    ///
+    /// The interpolation proceeds according to [CSS Color Module Level 4 § 12][css-sec].
+    ///
+    /// This method does a bunch of precomputation, resulting in an [`Interpolator`] object that
+    /// can be evaluated at various `t` values.
+    ///
+    /// [css-sec]: https://www.w3.org/TR/css-color-4/#interpolation
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use color::{AlphaColor, InterpolationAlphaSpace, ColorSpaceTag, DynamicColor, HueDirection, Srgb};
+    ///
+    /// let start = DynamicColor::from_alpha_color(AlphaColor::<Srgb>::new([1., 0., 0., 1.]));
+    /// let end = DynamicColor::from_alpha_color(AlphaColor::<Srgb>::new([0., 1., 0., 1.]));
+    ///
+    /// let interp = start.interpolate_with_alpha(end, ColorSpaceTag::Hsl, HueDirection::Increasing, InterpolationAlphaSpace::Premultiplied);
+    /// let mid = interp.eval(0.5);
+    /// assert_eq!(mid.cs, ColorSpaceTag::Hsl);
+    /// assert!((mid.components[0] - 60.).abs() < 0.01);
+    /// ```
+    pub fn interpolate_with_alpha(
+        self,
+        other: Self,
+        cs: ColorSpaceTag,
+        direction: HueDirection,
+        interpolation_alpha_space: InterpolationAlphaSpace,
+    ) -> Interpolator {
         let mut a = self.convert(cs);
         let mut b = other.convert(cs);
         let a_missing = a.flags.missing();
@@ -362,21 +403,22 @@ impl DynamicColor {
                 }
             }
         }
-        let (premul1, alpha1) = a.premultiply_split();
-        let (mut premul2, alpha2) = b.premultiply_split();
-        fixup_hues_for_interpolate(premul1, &mut premul2, cs.layout(), direction);
-        let delta_premul = [
-            premul2[0] - premul1[0],
-            premul2[1] - premul1[1],
-            premul2[2] - premul1[2],
+        let (color1, alpha1) = a.split(interpolation_alpha_space);
+        let (mut color2, alpha2) = b.split(interpolation_alpha_space);
+        fixup_hues_for_interpolate(color1, &mut color2, cs.layout(), direction);
+        let delta_color = [
+            color2[0] - color1[0],
+            color2[1] - color1[1],
+            color2[2] - color1[2],
         ];
         Interpolator {
-            premul1,
+            color1,
             alpha1,
-            delta_premul,
+            delta_color,
             delta_alpha: alpha2 - alpha1,
             cs,
             missing,
+            interpolation_alpha_space,
         }
     }
 
@@ -509,16 +551,19 @@ impl Interpolator {
     /// Typically `t` ranges between 0 and 1, but that is not enforced,
     /// so extrapolation is also possible.
     pub fn eval(&self, t: f32) -> DynamicColor {
-        let premul = [
-            self.premul1[0] + t * self.delta_premul[0],
-            self.premul1[1] + t * self.delta_premul[1],
-            self.premul1[2] + t * self.delta_premul[2],
+        let color = [
+            self.color1[0] + t * self.delta_color[0],
+            self.color1[1] + t * self.delta_color[1],
+            self.color1[2] + t * self.delta_color[2],
         ];
         let alpha = self.alpha1 + t * self.delta_alpha;
-        let opaque = if alpha == 0.0 || alpha == 1.0 {
-            premul
+        let opaque = if self.interpolation_alpha_space.is_unpremultiplied()
+            || alpha == 0.0
+            || alpha == 1.0
+        {
+            color
         } else {
-            self.cs.layout().scale(premul, 1.0 / alpha)
+            self.cs.layout().scale(color, 1.0 / alpha)
         };
         let components = add_alpha(opaque, alpha);
         DynamicColor {
@@ -531,7 +576,7 @@ impl Interpolator {
 
 #[cfg(test)]
 mod tests {
-    use crate::{parse_color, ColorSpaceTag, DynamicColor, Missing};
+    use crate::{parse_color, ColorSpaceTag, DynamicColor, InterpolationAlphaSpace, Missing};
 
     // `DynamicColor` was carefully packed. Ensure its size doesn't accidentally change.
     const _: () = if size_of::<DynamicColor>() != 20 {
@@ -675,6 +720,29 @@ mod tests {
     }
 
     #[test]
+    fn unpremultiplied_rectangular_interpolation() {
+        use crate::HueDirection;
+
+        // This interpolates in a rectangular color space from a fully transparent color to a fully
+        // opaque color (with premultiplied color channels). Both color should be contributing
+        // color information.
+        let start = parse_color("oklab(0.5 0.2 -0.1 / 0.0)").unwrap();
+        let end = parse_color("oklab(0.3 0.1 0.1 / 1.0)").unwrap();
+        let interp = start.interpolate_with_alpha(
+            end,
+            ColorSpaceTag::Oklab,
+            HueDirection::Increasing,
+            InterpolationAlphaSpace::Unpremultiplied,
+        );
+        let mid = interp.eval(0.5);
+
+        assert!((mid.components[0] - 0.4).abs() < 1e-4);
+        assert!((mid.components[1] - 0.15).abs() < 1e-4);
+        assert!((mid.components[2] - 0.0).abs() < 1e-4);
+        assert!((mid.components[3] - 0.5).abs() < 1e-4);
+    }
+
+    #[test]
     fn premultiplied_cylindrical_interpolation() {
         use crate::HueDirection;
 
@@ -689,6 +757,29 @@ mod tests {
 
         assert!((mid.components[0] - 0.3).abs() < 1e-4);
         assert!((mid.components[1] - 0.1).abs() < 1e-4);
+        assert!((mid.components[2] - 150.).abs() < 1e-4);
+        assert!((mid.components[3] - 0.5).abs() < 1e-4);
+    }
+
+    #[test]
+    fn unpremultiplied_cylindrical_interpolation() {
+        use crate::HueDirection;
+
+        // This interpolates in a cylandrical color space from a fully transparent color to a fully
+        // opaque color (with premultiplied color channels). The hue is not premultiplied, see
+        // [`crate::PremulColor`]. Both color should be contributing color information.
+        let start = parse_color("oklch(0.5 0.2 100 / 0.0)").unwrap();
+        let end = parse_color("oklch(0.3 0.1 200 / 1.0)").unwrap();
+        let interp = start.interpolate_with_alpha(
+            end,
+            ColorSpaceTag::Oklch,
+            HueDirection::Increasing,
+            InterpolationAlphaSpace::Unpremultiplied,
+        );
+        let mid = interp.eval(0.5);
+
+        assert!((mid.components[0] - 0.4).abs() < 1e-4);
+        assert!((mid.components[1] - 0.15).abs() < 1e-4);
         assert!((mid.components[2] - 150.).abs() < 1e-4);
         assert!((mid.components[3] - 0.5).abs() < 1e-4);
     }

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -275,7 +275,7 @@ impl DynamicColor {
         }
     }
 
-    pub(crate) fn split(self, alpha_type: InterpolationAlphaSpace) -> ([f32; 3], f32) {
+    fn split(self, alpha_type: InterpolationAlphaSpace) -> ([f32; 3], f32) {
         // Reference: §12.3 of Color 4 spec
         let (opaque, alpha) = split_alpha(self.components);
         let color = if alpha == 1.0

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -400,7 +400,6 @@ impl DynamicColor {
         }
     }
 
-    /// Interpolate two colors.
     /// Interpolate two colors without alpha premultiplication.
     ///
     /// Similar to [`DynamicColor::interpolate`], but colors are interpolated without premultiplying
@@ -836,8 +835,6 @@ mod tests {
     fn unpremultiplied_cylindrical_interpolation() {
         use crate::HueDirection;
 
-        // This interpolates in a cylandrical color space from a fully transparent color to a fully
-        // opaque color (with premultiplied color channels). The hue is not premultiplied, see
         // This interpolates in a cylindrical color space from a fully transparent color to a fully
         // opaque color (with unpremultiplied color channels). Both color should be contributing
         // color information.

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -358,8 +358,8 @@ impl DynamicColor {
     /// Interpolate two colors.
     /// Interpolate two colors without alpha premultiplication.
     ///
-    /// Similar to [`interpolate`], but colors are interpolated without premultiplying their color
-    /// channels by the alpha channel. This is almost never what you want.
+    /// Similar to [`DynamicColor::interpolate`], but colors are interpolated without premultiplying
+    /// their color channels by the alpha channel. This is almost never what you want.
     ///
     /// This causes color information to leak out of transparent colors. For example, when
     /// interpolating from a fully transparent red to a fully opaque blue in sRGB, this

--- a/color/src/dynamic.rs
+++ b/color/src/dynamic.rs
@@ -356,7 +356,20 @@ impl DynamicColor {
     }
 
     /// Interpolate two colors.
-    ///
+/// Interpolate two colors without alpha premultiplication.
+///
+/// Similar to [`interpolate`], but colors are interpolated without premultiplying their color
+/// channels by the alpha channel. This is almost never what you want.
+///
+/// This causes color information to leak out of transparent colors. For example, when
+/// interpolating from a fully transparent red to a fully opaque blue in sRGB, this
+/// method will go through an intermediate purple.
+///
+/// This matches behavior of gradients in the HTML `canvas` element.
+/// See [The 2D rendering context § Fill and stroke styles][HTML 2D Canvas] of the
+/// HTML 2D Canvas specification.
+///
+/// [HTML 2D Canvas]: https://html.spec.whatwg.org/multipage/#interpolation
     /// The colors are interpolated linearly from `self` to `other` in the color space given by
     /// `cs`. When interpolating in a cylindrical color space, the hue can be interpolated in
     /// multiple ways. The [`direction`](`HueDirection`) parameter controls the way in which the
@@ -738,7 +751,7 @@ mod tests {
         use crate::HueDirection;
 
         // This interpolates in a rectangular color space from a fully transparent color to a fully
-        // opaque color (with premultiplied color channels). Both color should be contributing
+        // opaque color (with unpremultiplied color channels). Both colors should be contributing
         // color information.
         let start = parse_color("oklab(0.5 0.2 -0.1 / 0.0)").unwrap();
         let end = parse_color("oklab(0.3 0.1 0.1 / 1.0)").unwrap();
@@ -777,7 +790,9 @@ mod tests {
 
         // This interpolates in a cylandrical color space from a fully transparent color to a fully
         // opaque color (with premultiplied color channels). The hue is not premultiplied, see
-        // [`crate::PremulColor`]. Both color should be contributing color information.
+        // This interpolates in a cylindrical color space from a fully transparent color to a fully
+        // opaque color (with unpremultiplied color channels). Both color should be contributing
+        // color information.
         let start = parse_color("oklch(0.5 0.2 100 / 0.0)").unwrap();
         let end = parse_color("oklch(0.3 0.1 200 / 1.0)").unwrap();
         let interp =

--- a/color/src/gradient.rs
+++ b/color/src/gradient.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::{
-    AlphaColor, ColorSpace, ColorSpaceTag, DynamicColor, HueDirection, InterpolationAlphaSpace,
-    Interpolator, Oklab, PremulColor,
+    AlphaColor, ColorSpace, ColorSpaceTag, DynamicColor, HueDirection, Interpolator, Oklab,
+    PremulColor,
 };
 
 /// The iterator for gradient approximation.
@@ -188,7 +188,7 @@ impl<CS: ColorSpace> Iterator for GradientIter<CS> {
 /// This will yield a value for each gradient stop, including `t` values
 /// of 0 and 1 at the endpoints.
 ///
-/// Use the [`unpremultiplied_gradient`] function to generate this iterator.
+/// Use the [`gradient_unpremultiplied`] function to generate this iterator.
 ///
 /// Similar to [`GradientIter`], but does interpolation in unpremultiplied (straight) alpha space
 /// as specified in [HTML 2D Canvas]
@@ -220,15 +220,15 @@ pub struct UnpremultipliedGradientIter<CS: ColorSpace> {
 /// piecewise in the color space sRGB.
 ///
 /// ```rust
-/// use color::{AlphaColor, InterpolationAlphaSpace, ColorSpaceTag, DynamicColor, HueDirection, Oklab, Srgb};
+/// use color::{AlphaColor, ColorSpaceTag, DynamicColor, HueDirection, Oklab, Srgb};
 ///
 /// let start = DynamicColor::from_alpha_color(AlphaColor::<Srgb>::new([1., 0., 0., 1.]));
 /// let end = DynamicColor::from_alpha_color(AlphaColor::<Srgb>::new([0., 1., 0., 1.]));
 ///
 /// // Interpolation in a target interpolation color space.
-/// let interp = start.interpolate_with_alpha(end, ColorSpaceTag::Oklab, HueDirection::default(), InterpolationAlphaSpace::Unpremultiplied);
+/// let interp = start.interpolate_unpremultiplied(end, ColorSpaceTag::Oklab, HueDirection::default());
 /// // Piecewise-approximated interpolation in a compositing color space.
-/// let mut gradient = color::unpremultiplied_gradient::<Srgb>(
+/// let mut gradient = color::gradient_unpremultiplied::<Srgb>(
 ///     start,
 ///     end,
 ///     ColorSpaceTag::Oklab,
@@ -259,19 +259,14 @@ pub struct UnpremultipliedGradientIter<CS: ColorSpace> {
 ///     stop0 = stop1;
 /// }
 /// ```
-pub fn unpremultiplied_gradient<CS: ColorSpace>(
+pub fn gradient_unpremultiplied<CS: ColorSpace>(
     mut color0: DynamicColor,
     mut color1: DynamicColor,
     interp_cs: ColorSpaceTag,
     direction: HueDirection,
     tolerance: f32,
 ) -> UnpremultipliedGradientIter<CS> {
-    let interpolator = color0.interpolate_with_alpha(
-        color1,
-        interp_cs,
-        direction,
-        InterpolationAlphaSpace::Unpremultiplied,
-    );
+    let interpolator = color0.interpolate_unpremultiplied(color1, interp_cs, direction);
     if !color0.flags.missing().is_empty() {
         color0 = interpolator.eval(0.0);
     }

--- a/color/src/gradient.rs
+++ b/color/src/gradient.rs
@@ -191,7 +191,7 @@ impl<CS: ColorSpace> Iterator for GradientIter<CS> {
 /// Use the [`gradient_unpremultiplied`] function to generate this iterator.
 ///
 /// Similar to [`GradientIter`], but does interpolation in unpremultiplied (straight) alpha space
-/// as specified in [HTML 2D Canvas]
+/// as specified in [HTML 2D Canvas].
 ///
 /// [HTML 2D Canvas]: https://html.spec.whatwg.org/multipage/#interpolation
 #[expect(missing_debug_implementations, reason = "it's an iterator")]
@@ -207,11 +207,20 @@ pub struct UnpremultipliedGradientIter<CS: ColorSpace> {
     end_color: AlphaColor<CS>,
 }
 
-/// Generate a piecewise linear approximation to a gradient ramp.
+/// Generate a piecewise linear approximation to a gradient ramp without alpha premultiplication.
 ///
 /// Similar to [`gradient`], but does interpolation in unpremultiplied (straight) alpha space
 /// as specified in [HTML 2D Canvas]
+/// Similar to [`gradient`], but colors are interpolated without premultiplying their color
+/// channels by the alpha channel. This is almost never what you want.
 ///
+/// This causes color information to leak out of transparent colors. For example, when
+/// interpolating from a fully transparent red to a fully opaque blue in sRGB, this
+/// method will go through an intermediate purple.
+///
+/// This matches behavior of gradients in the HTML `canvas` element.
+/// See [The 2D rendering context § Fill and stroke styles][HTML 2D Canvas] of the
+/// HTML 2D Canvas specification.
 /// [HTML 2D Canvas]: https://html.spec.whatwg.org/multipage/#interpolation
 ///
 /// # Example

--- a/color/src/gradient.rs
+++ b/color/src/gradient.rs
@@ -154,9 +154,11 @@ impl<CS: ColorSpace> Iterator for GradientIter<CS> {
         loop {
             // compute midpoint color
             let midpoint = self.interpolator.eval(t0 + 0.5 * self.dt);
-            let midpoint_oklab: PremulColor<Oklab> = midpoint.to_alpha_color().premultiply();
-            let approx = self.target0.lerp_rect(self.target1, 0.5);
-            let error = midpoint_oklab.difference(approx.convert());
+            let error = {
+                let midpoint_oklab: PremulColor<Oklab> = midpoint.to_alpha_color().premultiply();
+                let approx = self.target0.lerp_rect(self.target1, 0.5);
+                midpoint_oklab.difference(approx.convert())
+            };
             if error <= self.tolerance {
                 let t1 = t0 + self.dt;
                 self.t0 += 1;
@@ -221,7 +223,7 @@ pub struct UnpremultipliedGradientIter<CS: ColorSpace> {
 /// This matches behavior of gradients in the HTML `canvas` element.
 /// See [The 2D rendering context § Fill and stroke styles][HTML 2D Canvas] of the
 /// HTML 2D Canvas specification.
-/// [HTML 2D Canvas]: https://html.spec.whatwg.org/multipage/#interpolation
+/// [HTML 2D Canvas]: <https://html.spec.whatwg.org/multipage/#interpolation>
 ///
 /// # Example
 ///

--- a/color/src/gradient.rs
+++ b/color/src/gradient.rs
@@ -211,8 +211,6 @@ pub struct UnpremultipliedGradientIter<CS: ColorSpace> {
 
 /// Generate a piecewise linear approximation to a gradient ramp without alpha premultiplication.
 ///
-/// Similar to [`gradient`], but does interpolation in unpremultiplied (straight) alpha space
-/// as specified in [HTML 2D Canvas]
 /// Similar to [`gradient`], but colors are interpolated without premultiplying their color
 /// channels by the alpha channel. This is almost never what you want.
 ///
@@ -223,6 +221,7 @@ pub struct UnpremultipliedGradientIter<CS: ColorSpace> {
 /// This matches behavior of gradients in the HTML `canvas` element.
 /// See [The 2D rendering context § Fill and stroke styles][HTML 2D Canvas] of the
 /// HTML 2D Canvas specification.
+///
 /// [HTML 2D Canvas]: <https://html.spec.whatwg.org/multipage/#interpolation>
 ///
 /// # Example

--- a/color/src/gradient.rs
+++ b/color/src/gradient.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     AlphaColor, ColorSpace, ColorSpaceTag, DynamicColor, HueDirection, Interpolator, Oklab,
-    PremulColor,
+    PremulColor, UnpremultipliedInterpolator,
 };
 
 /// The iterator for gradient approximation.
@@ -198,7 +198,7 @@ impl<CS: ColorSpace> Iterator for GradientIter<CS> {
 /// [HTML 2D Canvas]: https://html.spec.whatwg.org/multipage/#interpolation
 #[expect(missing_debug_implementations, reason = "it's an iterator")]
 pub struct UnpremultipliedGradientIter<CS: ColorSpace> {
-    interpolator: Interpolator,
+    interpolator: UnpremultipliedInterpolator,
     // This is in deltaEOK units
     tolerance: f32,
     // The adaptive subdivision logic is lifted from the stroke expansion paper.

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -108,14 +108,14 @@ mod impl_bytemuck;
 mod floatfuncs;
 
 pub use chromaticity::Chromaticity;
-pub use color::{AlphaColor, HueDirection, OpaqueColor, PremulColor};
+pub use color::{AlphaColor, HueDirection, InterpolationAlphaSpace, OpaqueColor, PremulColor};
 pub use colorspace::{
     A98Rgb, Aces2065_1, AcesCg, ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch,
     LinearSrgb, Oklab, Oklch, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
 };
 pub use dynamic::{DynamicColor, Interpolator};
 pub use flags::{Flags, Missing};
-pub use gradient::{gradient, GradientIter};
+pub use gradient::{gradient, unpremultiplied_gradient, GradientIter, UnpremultipliedGradientIter};
 pub use parse::{parse_color, parse_color_prefix, ParseError};
 pub use rgba8::{PremulRgba8, Rgba8};
 pub use tag::ColorSpaceTag;

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -113,7 +113,7 @@ pub use colorspace::{
     A98Rgb, Aces2065_1, AcesCg, ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch,
     LinearSrgb, Oklab, Oklch, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
 };
-pub use dynamic::{DynamicColor, Interpolator};
+pub use dynamic::{DynamicColor, Interpolator, UnpremultipliedInterpolator};
 pub use flags::{Flags, Missing};
 pub use gradient::{gradient, gradient_unpremultiplied, GradientIter, UnpremultipliedGradientIter};
 pub use parse::{parse_color, parse_color_prefix, ParseError};

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -108,14 +108,14 @@ mod impl_bytemuck;
 mod floatfuncs;
 
 pub use chromaticity::Chromaticity;
-pub use color::{AlphaColor, HueDirection, InterpolationAlphaSpace, OpaqueColor, PremulColor};
+pub use color::{AlphaColor, HueDirection, OpaqueColor, PremulColor};
 pub use colorspace::{
     A98Rgb, Aces2065_1, AcesCg, ColorSpace, ColorSpaceLayout, DisplayP3, Hsl, Hwb, Lab, Lch,
     LinearSrgb, Oklab, Oklch, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
 };
 pub use dynamic::{DynamicColor, Interpolator};
 pub use flags::{Flags, Missing};
-pub use gradient::{gradient, unpremultiplied_gradient, GradientIter, UnpremultipliedGradientIter};
+pub use gradient::{gradient, gradient_unpremultiplied, GradientIter, UnpremultipliedGradientIter};
 pub use parse::{parse_color, parse_color_prefix, ParseError};
 pub use rgba8::{PremulRgba8, Rgba8};
 pub use tag::ColorSpaceTag;


### PR DESCRIPTION
Alternative implementiran of #185 that is NOT a breaking change. Functional wise it's the same (although there is no generalization of gradient iter code).

Fixes #184