### PR TITLE
(Temporarily) disable Miri's float randomization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,17 @@ jobs:
 
       - name: cargo miri
         run: cargo miri test --workspace --locked --all-features --target s390x-unknown-linux-gnu --no-fail-fast
+        env:
+          # We test color operations to somewhat tight bounds, including those
+          # where we use floating point operations with unspecified precision.
+          # These sometimes cause tests to fail under Miri. While these
+          # failures might not be false positives technically, it seems Miri's
+          # approach to float error randomization has not fully stabilized yet
+          # (see, e.g., https://github.com/rust-lang/miri/pull/4558, which as
+          # of writing is a week-old change). We pass a flag to Miri to disable
+          # randomization for now in CI. The plan is to remove this flag once
+          # Miri's approach has become more stable.
+          MIRIFLAGS: "-Zmiri-deterministic-floats"
 
   doc:
     name: cargo doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,11 +307,10 @@ jobs:
           # where we use floating point operations with unspecified precision.
           # These sometimes cause tests to fail under Miri. While these
           # failures might not be false positives technically, it seems Miri's
-          # approach to float error randomization has not fully stabilized yet
-          # (see, e.g., https://github.com/rust-lang/miri/pull/4558, which as
-          # of writing is a week-old change). We pass a flag to Miri to disable
-          # randomization for now in CI. The plan is to remove this flag once
-          # Miri's approach has become more stable.
+          # approach to float error randomization has not fully stabilized yet.
+          # We pass a flag to Miri to disable randomization for now in CI. We
+          # would like to remove this flag once Miri's approach becomes more
+          # stable.
           MIRIFLAGS: "-Zmiri-deterministic-floats"
 
   doc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,10 @@ jobs:
           # We pass a flag to Miri to disable randomization for now in CI. We
           # would like to remove this flag once Miri's approach becomes more
           # stable.
+          #
+          # This is tracked in https://github.com/linebender/color/issues/197,
+          # i.e., this flag is to be removed if that issue is closed as
+          # completed.
           MIRIFLAGS: "-Zmiri-deterministic-floats"
 
   doc:

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -1724,17 +1724,14 @@ mod tests {
     fn roundtrip() {
         fn test_roundtrips<Source: ColorSpace, Dest: ColorSpace>(colors: &[[f32; 3]]) {
             /// A tight bound on relative numerical precision.
-            #[cfg(not(miri))]
-            const RELATIVE_EPSILON: f32 = f32::EPSILON * 16.;
-
-            /// Miri uses precision randomization of floating point operations that do not have a
-            /// guaranteed precision.
             ///
-            /// Use a lower precision bound on Miri specifically. This is a bit messy, but on our
+            /// Some floating point operations we use from the standard library do not technically
+            /// have a specified precision. Testing under Miri may cause failures, as Miri
+            /// randomizes precision of floating point operations that do not have a guaranteed
+            /// precision. This tight bound is likely to fail under such randomization. On our
             /// target platforms, we'd still like to notice it we don't reach a tight precision
             /// bound anymore.
-            #[cfg(miri)]
-            const RELATIVE_EPSILON: f32 = f32::EPSILON * 1600.;
+            const RELATIVE_EPSILON: f32 = f32::EPSILON * 16.;
 
             for color in colors {
                 let intermediate = Source::convert::<Dest>(*color);


### PR DESCRIPTION
CI is sometimes failing by flakey tests when run under Miri, and I cannot reproduce the failures locally under Miri. We'd probably like to release 0.3.2 anyway.

We test color operations to somewhat tight bounds, including those where we use floating point operations with unspecified precision. These sometimes cause tests to fail under Miri. While these failures might not be false positives technically, it seems Miri's approach to float error randomization has not fully stabilized yet (see, e.g., https://github.com/rust-lang/miri/pull/4558, which as of writing is a week-old change). We pass a flag to Miri to disable randomization for now in CI. The plan is to remove this flag once Miri's approach has become more stable.

Rather than doing another localized fix (as in https://github.com/linebender/color/pull/182), this is likely the more honest approach for now.