### PR TITLE
Re-enable miri float randomization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,20 +302,6 @@ jobs:
 
       - name: cargo miri
         run: cargo miri test --workspace --locked --all-features --target s390x-unknown-linux-gnu --no-fail-fast
-        env:
-          # We test color operations to somewhat tight bounds, including those
-          # where we use floating point operations with unspecified precision.
-          # These sometimes cause tests to fail under Miri. While these
-          # failures might not be false positives technically, it seems Miri's
-          # approach to float error randomization has not fully stabilized yet.
-          # We pass a flag to Miri to disable randomization for now in CI. We
-          # would like to remove this flag once Miri's approach becomes more
-          # stable.
-          #
-          # This is tracked in https://github.com/linebender/color/issues/197,
-          # i.e., this flag is to be removed if that issue is closed as
-          # completed.
-          MIRIFLAGS: "-Zmiri-deterministic-floats"
 
   doc:
     name: cargo doc

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -1729,9 +1729,14 @@ mod tests {
             /// have a specified precision. Testing under Miri may cause failures, as Miri
             /// randomizes precision of floating point operations that do not have a guaranteed
             /// precision. This tight bound is likely to fail under such randomization. On our
-            /// target platforms, we'd still like to notice it we don't reach a tight precision
+            /// target platforms, we'd still like to notice if we don't reach a tight precision
             /// bound anymore.
+            #[cfg(not(miri))]
             const RELATIVE_EPSILON: f32 = f32::EPSILON * 16.;
+
+            /// Use a looser bound for Miri; see the comment above.
+            #[cfg(miri)]
+            const RELATIVE_EPSILON: f32 = f32::EPSILON * 1600.;
 
             for color in colors {
                 let intermediate = Source::convert::<Dest>(*color);


### PR DESCRIPTION
With changes in Miri and our changes in https://github.com/linebender/color/pull/207 we're probably able to re-enable Miri's float randomization. See https://github.com/linebender/color/pull/196. Fixes https://github.com/linebender/color/pull/197.