### PR TITLE
Set `Oklch::WHITE_COMPONENTS` to 0° hue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ This release has an [MSRV][] of 1.82.
 
 ### Changed
 
-* Breaking change: Skip serializing/deserializing `PhantomData` marker fields of `OpaqueColor`, `AlphaColor`, and `PremulColor` when the `serde` feature is enabled. ([#202][] by [@alvinisspicy][])
-* Breaking change: `Oklch::WHITE_COMPONENTS`'s hue is now 0° instead of 90°. ([#210][] by [@tomcur][])
+* Skip serializing/deserializing `PhantomData` marker fields of `OpaqueColor`, `AlphaColor`, and `PremulColor` when the `serde` feature is enabled. ([#202][] by [@alvinisspicy][])
+
+  This is technically a breaking change: data serialized with 0.3.2 or earlier will now fail to deserialize. 
+  We expect this to not be an issue in practice; if you do hit this issue, please let us know and we will re-evaluate.
+* `Oklch::WHITE_COMPONENTS`'s hue is now 0° instead of 90°. ([#210][] by [@tomcur][])
 * Mapping functions like `OpaqueColor::map` to take `FnOnce` instead of `Fn`. ([#211][] by [@tomcur][])
 
 ## [0.3.2][] (2025-09-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ This release has an [MSRV][] of 1.82.
 
 ### Changed
 
-* Skip serializing/deserializing `PhantomData` marker fields of `OpaqueColor`, `AlphaColor`, and `PremulColor` when the `serde` feature is enabled. ([#202][] by [@alvinisspicy][])
-* `Oklch::WHITE_COMPONENTS`'s hue is now 0° instead of 90°. ([#210][] by [@tomcur][])
+* Breaking change: Skip serializing/deserializing `PhantomData` marker fields of `OpaqueColor`, `AlphaColor`, and `PremulColor` when the `serde` feature is enabled. ([#202][] by [@alvinisspicy][])
+* Breaking change: `Oklch::WHITE_COMPONENTS`'s hue is now 0° instead of 90°. ([#210][] by [@tomcur][])
 * Mapping functions like `OpaqueColor::map` to take `FnOnce` instead of `Fn`. ([#211][] by [@tomcur][])
 
 ## [0.3.2][] (2025-09-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This release has an [MSRV][] of 1.82.
 ### Changed
 
 * Skip serializing/deserializing `PhantomData` marker fields of `OpaqueColor`, `AlphaColor`, and `PremulColor` when the `serde` feature is enabled. ([#202][] by [@alvinisspicy][])
+* `Oklch::WHITE_COMPONENTS`'s hue is now 0° instead of 90°. ([#210][] by [@tomcur][])
 * Mapping functions like `OpaqueColor::map` to take `FnOnce` instead of `Fn`. ([#211][] by [@tomcur][])
 
 ## [0.3.2][] (2025-09-10)
@@ -216,6 +217,7 @@ This is the initial release.
 [#185]: https://github.com/linebender/color/pull/185
 [#190]: https://github.com/linebender/color/pull/190
 [#202]: https://github.com/linebender/color/pull/202
+[#210]: https://github.com/linebender/color/pull/210
 [#211]: https://github.com/linebender/color/pull/211
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.3.2...HEAD

--- a/color/src/colorspace.rs
+++ b/color/src/colorspace.rs
@@ -1292,7 +1292,7 @@ impl ColorSpace for Oklch {
 
     const LAYOUT: ColorSpaceLayout = ColorSpaceLayout::HueThird;
 
-    const WHITE_COMPONENTS: [f32; 3] = [1., 0., 90.];
+    const WHITE_COMPONENTS: [f32; 3] = [1., 0., 0.];
 
     fn from_linear_srgb(src: [f32; 3]) -> [f32; 3] {
         lab_to_lch(Oklab::from_linear_srgb(src))


### PR DESCRIPTION
It's currently 90° on `main`, which is harmless as with 0 chroma it is powerless, but 0° is probably the more expected default.