### PR TITLE
feat: external `from_hex` function

### DIFF
--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -109,6 +109,7 @@ mod impl_bytemuck;
 #[cfg(all(not(feature = "std"), not(test)))]
 mod floatfuncs;
 
+use crate::parse::{color_from_4bit_hex, get_4bit_hex_channels};
 pub use chromaticity::Chromaticity;
 pub use color::{AlphaColor, HueDirection, OpaqueColor, PremulColor};
 pub use colorspace::{
@@ -191,12 +192,12 @@ impl AlphaColor<Srgb> {
     }
 
     /// Create a color from a hexadecimal value.
-    pub fn from_hex(hex: &str) -> Self {
-        let components = match parse_color(hex) {
-            Ok(c) => c,
-            Err(_) => return Self::WHITE,
-        };
-        Self::new(components.components)
+    pub const fn from_hex(hex: &str) -> Result<Self, ParseError> {
+        let bit_hex = get_4bit_hex_channels(hex);
+        match bit_hex {
+            Ok((_, channels)) => Ok(color_from_4bit_hex(channels)),
+            Err(e) => Err(ParseError::UnknownColorComponent),
+        }
     }
 }
 
@@ -208,16 +209,12 @@ impl OpaqueColor<Srgb> {
     }
 
     /// Create a color from a hexadecimal value.
-    pub fn from_hex(hex: &str) -> Self {
-        let components = match parse_color(hex) {
-            Ok(c) => c,
-            Err(_) => return Self::WHITE,
-        };
-        Self::new([
-            components.components[0],
-            components.components[1],
-            components.components[2],
-        ])
+    pub const fn from_hex(hex: &str) -> Result<Self, ParseError> {
+        let bit_hex = get_4bit_hex_channels(hex);
+        match bit_hex {
+            Ok((_, channels)) => Ok(color_from_4bit_hex(channels).discard_alpha()),
+            Err(e) => Err(ParseError::UnknownColorComponent),
+        }
     }
 }
 

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -213,7 +213,11 @@ impl OpaqueColor<Srgb> {
             Ok(c) => c,
             Err(_) => return OpaqueColor::WHITE,
         };
-        Self::new([components.components[0], components.components[1], components.components[2]])
+        Self::new([
+            components.components[0],
+            components.components[1],
+            components.components[2],
+        ])
     }
 }
 

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -196,7 +196,7 @@ impl AlphaColor<Srgb> {
         let bit_hex = get_4bit_hex_channels(hex);
         match bit_hex {
             Ok((_, channels)) => Ok(color_from_4bit_hex(channels)),
-            Err(e) => Err(ParseError::UnknownColorComponent),
+            Err(e) => Err(e),
         }
     }
 }
@@ -213,7 +213,7 @@ impl OpaqueColor<Srgb> {
         let bit_hex = get_4bit_hex_channels(hex);
         match bit_hex {
             Ok((_, channels)) => Ok(color_from_4bit_hex(channels).discard_alpha()),
-            Err(e) => Err(ParseError::UnknownColorComponent),
+            Err(e) => Err(e),
         }
     }
 }

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -194,7 +194,7 @@ impl AlphaColor<Srgb> {
     pub fn from_hex(hex: &str) -> Self {
         let components = match parse_color(hex) {
             Ok(c) => c,
-            Err(_) => return AlphaColor::WHITE,
+            Err(_) => return Self::WHITE,
         };
         Self::new(components.components)
     }
@@ -211,7 +211,7 @@ impl OpaqueColor<Srgb> {
     pub fn from_hex(hex: &str) -> Self {
         let components = match parse_color(hex) {
             Ok(c) => c,
-            Err(_) => return OpaqueColor::WHITE,
+            Err(_) => return Self::WHITE,
         };
         Self::new([
             components.components[0],

--- a/color/src/lib.rs
+++ b/color/src/lib.rs
@@ -189,6 +189,15 @@ impl AlphaColor<Srgb> {
         let components = [u8_to_f32(r), u8_to_f32(g), u8_to_f32(b), 1.];
         Self::new(components)
     }
+
+    /// Create a color from a hexadecimal value.
+    pub fn from_hex(hex: &str) -> Self {
+        let components = match parse_color(hex) {
+            Ok(c) => c,
+            Err(_) => return AlphaColor::WHITE,
+        };
+        Self::new(components.components)
+    }
 }
 
 impl OpaqueColor<Srgb> {
@@ -196,6 +205,15 @@ impl OpaqueColor<Srgb> {
     pub const fn from_rgb8(r: u8, g: u8, b: u8) -> Self {
         let components = [u8_to_f32(r), u8_to_f32(g), u8_to_f32(b)];
         Self::new(components)
+    }
+
+    /// Create a color from a hexadecimal value.
+    pub fn from_hex(hex: &str) -> Self {
+        let components = match parse_color(hex) {
+            Ok(c) => c,
+            Err(_) => return OpaqueColor::WHITE,
+        };
+        Self::new([components.components[0], components.components[1], components.components[2]])
     }
 }
 

--- a/color/src/parse.rs
+++ b/color/src/parse.rs
@@ -616,7 +616,7 @@ impl<CS: ColorSpace> FromStr for PremulColor<CS> {
 ///
 /// Returns the parsed channels and the byte offset to the remainder of the string (i.e., the
 /// number of hex characters parsed).
-const fn get_4bit_hex_channels(hex_str: &str) -> Result<(usize, [u8; 8]), ParseError> {
+pub(crate) const fn get_4bit_hex_channels(hex_str: &str) -> Result<(usize, [u8; 8]), ParseError> {
     let mut hex = [0; 8];
 
     let mut i = 0;
@@ -651,7 +651,7 @@ const fn hex_from_ascii_byte(b: u8) -> Result<u8, ()> {
     }
 }
 
-const fn color_from_4bit_hex(components: [u8; 8]) -> AlphaColor<Srgb> {
+pub(crate) const fn color_from_4bit_hex(components: [u8; 8]) -> AlphaColor<Srgb> {
     let [r0, r1, g0, g1, b0, b1, a0, a1] = components;
     AlphaColor::from_rgba8(
         (r0 << 4) | r1,


### PR DESCRIPTION
This PR adds a new Color function `from_hex` in addition to `from_rgb8` and `from_rgba8`.

I'm not sure about the name, since it does more than just hex, so maybe `from_css`?