### PR TITLE
Bump MSRV to 1.86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # plus all the README.md files of the affected packages.
-  RUST_MIN_VER: "1.82"
+  RUST_MIN_VER: "1.86"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
   RUST_MIN_VER_PKGS: "-p color -p color_operations"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This release has an [MSRV][] of 1.86.
 
 ### Changed
 
-- `Flags::set_missing`, `Flags::discard_name`, `Flags::set_named_color_space`, and `Missing::insert` are now `const` thanks to the MSRV update. ([#xxx] by [@DJMcNab][])
+- `Flags::set_missing`, `Flags::discard_name`, `Flags::set_named_color_space`, and `Missing::insert` are now `const` thanks to the MSRV update. ([#218][] by [@DJMcNab][])
 
 ## [0.3.3][] (2026-05-05)
 
@@ -230,6 +230,7 @@ This is the initial release.
 [#202]: https://github.com/linebender/color/pull/202
 [#210]: https://github.com/linebender/color/pull/210
 [#211]: https://github.com/linebender/color/pull/211
+[#218]: https://github.com/linebender/color/pull/218
 
 [Unreleased]: https://github.com/linebender/color/compare/v0.3.3...HEAD
 [0.3.3]: https://github.com/linebender/color/releases/tag/v0.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ You can find its changes [documented below](#033-2026-05-05).
 
 ## [Unreleased][]
 
-This release has an [MSRV][] of 1.82.
+This release has an [MSRV][] of 1.86.
+
+### Changed
+
+- `Flags::set_missing`, `Flags::discard_name`, `Flags::set_named_color_space`, and `Missing::insert` are now `const` thanks to the MSRV update. ([#xxx] by [@DJMcNab][])
 
 ## [0.3.3][] (2026-05-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,7 @@ version = "0.3.3"
 edition = "2021"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
-# When updating to 1.83 or later, update `color/src/flags.rs` and remove this note.
-# When updating to 1.84 or later, update `color/src/floatfuncs.rs` and remove this note.
-rust-version = "1.82"
+rust-version = "1.86"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/color"
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It closely follows the [CSS Color Level 4] draft spec.
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Color has been verified to compile with **Rust 1.82** and later.
+This version of Color has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Color might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/color/README.md
+++ b/color/README.md
@@ -109,7 +109,7 @@ At least one of `std` and `libm` is required; `std` overrides `libm`.
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Color has been verified to compile with **Rust 1.82** and later.
+This version of Color has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Color might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/color/src/flags.rs
+++ b/color/src/flags.rs
@@ -56,11 +56,7 @@ impl Flags {
 
     /// Set the missing components.
     #[inline]
-    #[warn(
-        clippy::missing_const_for_fn,
-        reason = "can be made const with MSRV 1.83"
-    )]
-    pub fn set_missing(&mut self, missing: Missing) {
+    pub const fn set_missing(&mut self, missing: Missing) {
         self.missing = missing;
     }
 
@@ -91,11 +87,7 @@ impl Flags {
 
     /// Set the flags to indicate the color was specified using one of the named color space
     /// functions.
-    #[warn(
-        clippy::missing_const_for_fn,
-        reason = "can be made const with MSRV 1.83"
-    )]
-    pub(crate) fn set_named_color_space(&mut self) {
+    pub(crate) const fn set_named_color_space(&mut self) {
         self.name = 255;
     }
 
@@ -120,11 +112,7 @@ impl Flags {
 
     /// Discard the color name or color space name from the flags.
     #[inline]
-    #[warn(
-        clippy::missing_const_for_fn,
-        reason = "can be made const with MSRV 1.83"
-    )]
-    pub fn discard_name(&mut self) {
+    pub const fn discard_name(&mut self) {
         self.name = 0;
     }
 }
@@ -159,11 +147,7 @@ impl Missing {
 
     /// Add a missing component index to the set.
     #[inline]
-    #[warn(
-        clippy::missing_const_for_fn,
-        reason = "can be made const with MSRV 1.83"
-    )]
-    pub fn insert(&mut self, ix: usize) {
+    pub const fn insert(&mut self, ix: usize) {
         self.0 |= Self::single(ix).0;
     }
 

--- a/color/src/floatfuncs.rs
+++ b/color/src/floatfuncs.rs
@@ -42,7 +42,6 @@ define_float_funcs! {
     fn hypot(self, other: Self) -> Self => hypotf;
     // Note: powi is missing because its libm implementation is not efficient
     fn powf(self, n: Self) -> Self => powf;
-    fn round(self) -> Self => roundf;
     fn sin_cos(self) -> (Self, Self) => sincosf;
     fn sqrt(self) -> Self => sqrtf;
 }

--- a/color/src/floatfuncs.rs
+++ b/color/src/floatfuncs.rs
@@ -1,14 +1,6 @@
 // Copyright 2024 the Color Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// In Rust 1.84 (https://github.com/rust-lang/rust/pull/131304), `abs` and
-// `copysign` were added to `core`, so we no longer need these forwarded to
-// libm.
-#![cfg_attr(
-    not(feature = "std"),
-    expect(dead_code, reason = "abs and copysign were added to core in 1.84")
-)]
-
 //! Shims for math functions that ordinarily come from std.
 
 /// Defines a trait that chooses between libstd or libm implementations of float methods.
@@ -43,13 +35,9 @@ macro_rules! define_float_funcs {
 }
 
 define_float_funcs! {
-    // This is not needed once the MSRV is 1.84 or later.
-    fn abs(self) -> Self => fabsf;
     fn atan2(self, other: Self) -> Self => atan2f;
     fn cbrt(self) -> Self => cbrtf;
     fn ceil(self) -> Self => ceilf;
-    // This is not needed once the MSRV is 1.84 or later.
-    fn copysign(self, sign: Self) -> Self => copysignf;
     fn floor(self) -> Self => floorf;
     fn hypot(self, other: Self) -> Self => hypotf;
     // Note: powi is missing because its libm implementation is not efficient

--- a/color_operations/README.md
+++ b/color_operations/README.md
@@ -17,7 +17,7 @@ The Color Operations library provides functionality for ...
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Color Operations has been verified to compile with **Rust 1.82** and later.
+This version of Color Operations has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Color Operations might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.


### PR DESCRIPTION
This was released in April 2025, which is now more than a year ago. The reason I want this now is #217, but it
does also have user-facing improvements to constness.

I used Claude (Opus 4.6) to create the changelog entry.